### PR TITLE
Add TRT-LLM as server engine option

### DIFF
--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -367,7 +367,7 @@ def server_options(func):
     func = click.option(
         "--server-engine",
         type=click.Choice(
-            ["vLLM", "SGLang", "TGI", "cohere-TensorRT", "cohere-vLLM", "LlamaCPP"],
+            ["vLLM", "SGLang", "TGI", "TRT-LLM", "cohere-TensorRT", "cohere-vLLM", "LlamaCPP"],
             case_sensitive=True,
         ),
         required=False,


### PR DESCRIPTION
## Summary
- Add TensorRT-LLM (`TRT-LLM`) as a valid option for the `--server-engine` flag

This allows users to specify TRT-LLM as the inference engine when running benchmarks, alongside existing options like vLLM, SGLang, TGI, etc.

## Test plan
- [ ] Verify `--server-engine TRT-LLM` is accepted by the CLI
- [ ] Run `genai-bench benchmark --help` to confirm the option appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)