### PR TITLE
Fix crash loop: only exit on CRITICAL, not ERROR

### DIFF
--- a/genai_bench/logging.py
+++ b/genai_bench/logging.py
@@ -68,8 +68,8 @@ class DelayedRichHandler(RichHandler):
             # Emit normally after flushing
             super().emit(record)
 
-        # Exit on error logs
-        if record.levelno >= logging.ERROR:
+        # Exit on critical logs only (not ERROR - allows recoverable errors like 404s)
+        if record.levelno >= logging.CRITICAL:
             self.flush_buffer()
             sys.exit(1)
 


### PR DESCRIPTION
## Summary

- Change `sys.exit(1)` trigger from ERROR level to CRITICAL level in `DelayedRichHandler`
- Prevents crash loops when users provide incorrect configuration (e.g., wrong model name causing 404s)

## Problem

Previously, any ERROR log would trigger `sys.exit(1)`, causing:
- Immediate crash on first 404 (wrong model name)
- Crash loops when the benchmark runner retries
- No useful output for debugging

## Solution

Only exit on CRITICAL logs. Recoverable errors like HTTP 404s are logged but the benchmark continues, reporting 0 successful requests which correctly indicates the failure without crashing.

## Test plan

- [x] Run benchmark with incorrect model name - should complete with 0 requests instead of crashing
- [x] Run benchmark with correct config - should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)