### PR TITLE
docs: add CPU-only PyTorch installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ It provides detailed insights into model serving performance, offering both a us
 **Quick Start**: Install with `pip install genai-bench`.
 Alternatively, check [Installation Guide](https://docs.sglang.ai/genai-bench/getting-started/installation) for other options.
 
+### Running with CPU-Only PyTorch
+
+When running genai-bench on GPU machines, PyTorch may install GPU-enabled wheels by default, which are significantly larger (~2GB+) than CPU-only wheels (~200MB). Since genai-bench primarily uses PyTorch for tokenization (not GPU computation), you can force CPU-only PyTorch installation to reduce download size and installation time.
+
+**Option 1**: Use `--torch-backend=cpu` flag with `uv`:
+
+```bash
+uv run -p 3.13 --torch-backend=cpu --with git+https://github.com/basetenlabs/genai-bench.git genai-bench benchmark
+```
+
+**Option 2**: Use `UV_TORCH_BACKEND=cpu` environment variable:
+
+```bash
+UV_TORCH_BACKEND=cpu uv run -p 3.13 --with git+https://github.com/basetenlabs/genai-bench.git genai-bench benchmark
+```
+
+For more details, see the [Installation Guide](https://docs.sglang.ai/genai-bench/getting-started/installation#running-with-cpu-only-pytorch).
+
 ## How to use
 
 ### Quick Start

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -149,6 +149,38 @@ If you encounter issues:
    - Full error message
    - Steps to reproduce
 
+## Running with CPU-Only PyTorch
+
+When running genai-bench on GPU machines, PyTorch may install GPU-enabled wheels by default, which are significantly larger (~2GB+) than CPU-only wheels (~200MB). Since genai-bench primarily uses PyTorch for tokenization (not GPU computation), you can force CPU-only PyTorch installation to reduce download size and installation time.
+
+### Option 1: Use `--torch-backend=cpu` flag
+
+Add the `--torch-backend=cpu` flag when running with `uv`:
+
+```bash
+uv run -p 3.13 --torch-backend=cpu --with git+https://github.com/basetenlabs/genai-bench.git genai-bench benchmark
+```
+
+### Option 2: Use `UV_TORCH_BACKEND=cpu` environment variable
+
+Set the environment variable:
+
+```bash
+UV_TORCH_BACKEND=cpu uv run -p 3.13 --with git+https://github.com/basetenlabs/genai-bench.git genai-bench benchmark
+```
+
+### Verification
+
+After installation, verify CPU-only PyTorch is installed:
+
+```bash
+# Check torch version (should show +cpu suffix)
+python -c "import torch; print(torch.__version__)"
+
+# Verify CUDA is not available
+python -c "import torch; print(torch.cuda.is_available())"  # Should print False
+```
+
 ## Next Steps
 
 After successful installation:


### PR DESCRIPTION
## Summary

Add documentation for forcing CPU-only PyTorch installation when running genai-bench on GPU machines. This reduces download size from ~2GB+ to ~200MB since genai-bench primarily uses PyTorch for tokenization, not GPU computation.

## Changes

- Added new section "Running with CPU-Only PyTorch" to installation guide
- Added new section to README.md with quick reference
- Documented two options:
  1. Using `--torch-backend=cpu` flag
  2. Using `UV_TORCH_BACKEND=cpu` environment variable
- Included verification steps to confirm CPU-only PyTorch is installed

## Motivation

When running `uv run -p 3.13 --with git+https://github.com/basetenlabs/genai-bench.git genai-bench benchmark` on GPU machines, UV installs PyTorch GPU wheels by default, which are unnecessarily large and include CUDA runtime. Since genai-bench only uses PyTorch for tokenization (not GPU computation), forcing CPU-only installation significantly reduces download size and installation time.

## Testing

Verified documentation is clear and complete. Users can now:
- Use `--torch-backend=cpu` flag to force CPU-only PyTorch
- Use `UV_TORCH_BACKEND=cpu` environment variable for global configuration
- Verify installation with provided commands