### PR TITLE
Add --no-min-tokens flag to skip min_tokens in requests

### DIFF
--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -87,6 +87,7 @@ def benchmark(
     traffic_scenario,
     disable_streaming,
     additional_request_params,
+    no_min_tokens,
     # Model auth options
     model_auth_type,
     model_api_key,
@@ -363,6 +364,7 @@ def benchmark(
         data=data,
         additional_request_params=additional_request_params,
         dataset_config=dataset_config_obj,
+        no_min_tokens=no_min_tokens,
     )
 
     # If user did not provide scenarios but provided a dataset, default to dataset mode

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -300,6 +300,14 @@ def oci_auth_options(func):
 # Group sampling-related options
 def sampling_options(func):
     func = click.option(
+        "--no-min-tokens",
+        is_flag=True,
+        default=False,
+        help="Disable sending min_tokens in requests. Useful for backends that don't "
+        "support min_tokens (e.g., vLLM with speculative decoding). When enabled, "
+        "only max_tokens will be sent.",
+    )(func)
+    func = click.option(
         "--dataset-config",
         type=click.Path(exists=True),
         default=None,

--- a/genai_bench/sampling/base.py
+++ b/genai_bench/sampling/base.py
@@ -32,6 +32,7 @@ class Sampler(ABC):
         output_modality: str,
         additional_request_params: Optional[dict] = None,
         dataset_config: Optional[DatasetConfig] = None,
+        no_min_tokens: bool = False,
         **kwargs,
     ):
         """Initializes the Sampler.
@@ -44,6 +45,7 @@ class Sampler(ABC):
                 "embeddings").
             additional_request_params (Optional[dict]): Additional parameters
                 for the request.
+            no_min_tokens (bool): If True, don't send min_tokens in requests.
             **kwargs: Additional keyword arguments.
         """
         self.tokenizer = tokenizer
@@ -52,6 +54,7 @@ class Sampler(ABC):
         self.additional_request_params = additional_request_params or {}
         self.batch_size = 1  # Default batch size
         self.dataset_config = dataset_config
+        self.no_min_tokens = no_min_tokens
 
     def get_token_length(self, text: str, add_special_tokens: bool = False) -> int:
         """Get the token length of text using the current tokenizer.

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -36,7 +36,12 @@ class TextSampler(Sampler):
         **kwargs,
     ):
         super().__init__(
-            tokenizer, model, output_modality, additional_request_params, dataset_config
+            tokenizer,
+            model,
+            output_modality,
+            additional_request_params,
+            dataset_config,
+            **kwargs,
         )
 
         self.data = data
@@ -98,7 +103,8 @@ class TextSampler(Sampler):
         if num_output_tokens is not None:
             # Set both min and max to the desired output to ensure exact token count
             # This works with ignore_eos=True to guarantee the output length
-            self.additional_request_params["min_tokens"] = num_output_tokens
+            if not self.no_min_tokens:
+                self.additional_request_params["min_tokens"] = num_output_tokens
             self.additional_request_params["max_tokens"] = num_output_tokens
 
         return UserChatRequest(
@@ -371,7 +377,8 @@ class TextSampler(Sampler):
         # Set min_tokens and max_tokens from scenario's desired output
         # This ensures the model generates the expected number of tokens
         # Scenario values take precedence over user-provided values to ensure benchmark consistency
-        self.additional_request_params["min_tokens"] = output_len
+        if not self.no_min_tokens:
+            self.additional_request_params["min_tokens"] = output_len
         self.additional_request_params["max_tokens"] = output_len
 
         return UserChatRequest(

--- a/tests/sampling/test_text.py
+++ b/tests/sampling/test_text.py
@@ -548,3 +548,84 @@ class TestTextSamplerPrefixRepetition(unittest.TestCase):
 
         # Second sampler should have empty cache
         self.assertEqual(len(sampler2._shared_prefix_cache), 0)
+
+
+class TestTextSamplerNoMinTokens(unittest.TestCase):
+    """Test the no_min_tokens flag functionality."""
+
+    def setUp(self):
+        self.test_data = ["Test line 1", "Test line 2", "Test line 3"]
+        self.tokenizer = MagicMock()
+        self.model = "mock_model"
+        self.output_modality = "text"
+
+    def test_chat_request_with_min_tokens_by_default(self):
+        """Test that min_tokens is set by default."""
+        from genai_bench.scenarios.text import DeterministicDistribution
+
+        self.tokenizer.encode.return_value = [1] * 100
+        self.tokenizer.decode.return_value = "test text"
+
+        sampler = TextSampler(
+            tokenizer=self.tokenizer,
+            model=self.model,
+            output_modality=self.output_modality,
+            data=self.test_data,
+            # no_min_tokens defaults to False
+        )
+
+        scenario = DeterministicDistribution(num_input_tokens=100, num_output_tokens=50)
+        request = sampler._sample_chat_request(scenario)
+
+        self.assertIn("min_tokens", request.additional_request_params)
+        self.assertEqual(request.additional_request_params["min_tokens"], 50)
+        self.assertIn("max_tokens", request.additional_request_params)
+
+    def test_chat_request_without_min_tokens_when_flag_set(self):
+        """Test that min_tokens is NOT set when no_min_tokens=True."""
+        from genai_bench.scenarios.text import DeterministicDistribution
+
+        self.tokenizer.encode.return_value = [1] * 100
+        self.tokenizer.decode.return_value = "test text"
+
+        sampler = TextSampler(
+            tokenizer=self.tokenizer,
+            model=self.model,
+            output_modality=self.output_modality,
+            data=self.test_data,
+            no_min_tokens=True,
+        )
+
+        scenario = DeterministicDistribution(num_input_tokens=100, num_output_tokens=50)
+        request = sampler._sample_chat_request(scenario)
+
+        self.assertNotIn("min_tokens", request.additional_request_params)
+        self.assertIn("max_tokens", request.additional_request_params)
+        self.assertEqual(request.additional_request_params["max_tokens"], 50)
+
+    def test_prefix_repetition_without_min_tokens(self):
+        """Test that min_tokens is excluded in prefix repetition when flag is set."""
+        from genai_bench.scenarios.text import PrefixRepetitionScenario
+
+        self.tokenizer.encode.return_value = [1] * 100
+        self.tokenizer.decode.return_value = "test text"
+
+        sampler = TextSampler(
+            tokenizer=self.tokenizer,
+            model=self.model,
+            output_modality=self.output_modality,
+            data=self.test_data,
+            no_min_tokens=True,
+        )
+
+        scenario = PrefixRepetitionScenario(
+            prefix_len=2000,
+            suffix_len=500,
+            output_len=200,
+        )
+
+        request = sampler._sample_prefix_repetition_request(scenario)
+
+        self.assertNotIn("min_tokens", request.additional_request_params)
+        self.assertIn("max_tokens", request.additional_request_params)
+        self.assertEqual(request.additional_request_params["max_tokens"], 200)


### PR DESCRIPTION
This flag is useful for backends that don't support min_tokens, such as vLLM with speculative decoding enabled.

Changes:
- Add --no-min-tokens CLI flag in sampling_options
- Pass no_min_tokens parameter through to TextSampler
- Skip setting min_tokens when no_min_tokens=True

Usage:
  genai-bench benchmark --no-min-tokens ...

## Description
<!--Please provide a brief description of the changes in this PR.-->

## Related Issue
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->

## Changes
<!-- 
List the changes made in this PR.
-->

## Correctness Tests
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## Checklist
- [ ] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [ ] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [ ] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [ ] I have added tests that fail without my code changes (for bug fixes)
- [ ] I have added tests covering variants of new features (for new features)

## Additional Information
Add any other context, screenshots, or information about the PR here.
