### PR TITLE
feat: Add support for message list datasets in OpenAI chat format

### DIFF
--- a/docs/getting-started/cli-guidelines.md
+++ b/docs/getting-started/cli-guidelines.md
@@ -58,6 +58,7 @@ genai-bench benchmark --api-backend sglang \
 - `--dataset-config` - JSON config file for advanced dataset options, more info in [Selecting Datasets](../user-guide/run-benchmark.md/#selecting-datasets)
 - `--dataset-prompt-column` - Column name for prompts
 - `--dataset-image-column` - Column name for images (multimodal)
+- `--dataset-message-format` - Format for message list datasets (currently supports `openai`). Use with `--traffic-scenario dataset` when your dataset contains pre-structured chat conversations
 
 #### **Server Information**
 - `--server-engine` - Backend engine (vLLM, SGLang, TGI, etc.)

--- a/docs/user-guide/run-benchmark.md
+++ b/docs/user-guide/run-benchmark.md
@@ -518,6 +518,53 @@ If you want to benchmark a specific portion of a vision dataset, you can use the
 }
 ```
 
+**Using message lists (multi-turn chat):**
+
+If your dataset contains pre-structured conversations in OpenAI chat format, use `--dataset-message-format openai`. Each row should contain a list of message objects with `role` and `content` fields.
+
+Supported roles: `system`, `user`, `assistant`.
+
+Example dataset row (JSON):
+```json
+[
+  {"role": "system", "content": "You are a helpful assistant."},
+  {"role": "user", "content": "What is 2+2?"},
+  {"role": "assistant", "content": "4"},
+  {"role": "user", "content": "And 3+3?"}
+]
+```
+
+CLI usage:
+```bash
+genai-bench benchmark \
+  --task text-to-text \
+  --dataset-path my-org/multi-turn-dataset \
+  --dataset-prompt-column messages \
+  --dataset-message-format openai \
+  --traffic-scenario dataset \
+  --api-backend openai \
+  --api-base http://localhost:8000 \
+  --api-model-name my-model \
+  --num-concurrency 1
+```
+
+Config file usage:
+```json
+{
+  "source": {
+    "type": "huggingface",
+    "path": "my-org/multi-turn-dataset",
+    "huggingface_kwargs": {
+      "split": "train"
+    }
+  },
+  "prompt_column": "messages",
+  "message_format": "openai"
+}
+```
+
+Message lists are sent directly to the API as the `messages` parameter, preserving multi-turn context. This is useful for benchmarking with realistic conversation histories. Always use `--traffic-scenario dataset` with message lists, as token shaping scenarios are not compatible with pre-structured messages.
+
 **Benefits of config files:**
 
 - Access to ALL HuggingFace `load_dataset` parameters

--- a/docs/user-guide/scenario-definition.md
+++ b/docs/user-guide/scenario-definition.md
@@ -58,6 +58,7 @@ Behavior by task in dataset mode:
 - text-to-text
       - Picks a single line from your dataset as the prompt
       - Sets `max_tokens=None` and `ignore_eos=False` to avoid token shaping
+      - If `--dataset-message-format openai` is set, sends pre-structured message lists directly as the `messages` parameter (see [Selecting Datasets](run-benchmark.md/#selecting-datasets))
 - text-to-embeddings
       - Samples `batch_size` lines from your dataset per request
       - No token shaping is applied

--- a/genai_bench/async_runner/base.py
+++ b/genai_bench/async_runner/base.py
@@ -15,6 +15,7 @@ except ImportError:
 from genai_bench.logging import init_logger
 from genai_bench.metrics.request_metrics_collector import RequestMetricsCollector
 from genai_bench.protocol import (
+    UserChatMessagesRequest,
     UserChatRequest,
     UserChatResponse,
     UserEmbeddingRequest,
@@ -154,7 +155,11 @@ class BaseAsyncRunner:
         """Prepare a request from a scenario string or Scenario object."""
         # Accept either a prebuilt Scenario or a scenario string, for parity with Locust path
         if isinstance(scenario_input, str):
-            scenario_obj = Scenario.from_string(scenario_input)
+            # Special case: "dataset" means use dataset mode (pass None to sampler)
+            if scenario_input == "dataset":
+                scenario_obj = None
+            else:
+                scenario_obj = Scenario.from_string(scenario_input)
         else:
             scenario_obj = scenario_input
         req = self.sampler.sample(scenario_obj)
@@ -166,10 +171,19 @@ class BaseAsyncRunner:
             )
 
         # Validate request type matches API backend expectations
-        if isinstance(req, (UserChatRequest, UserImageChatRequest)):
+        if isinstance(
+            req, (UserChatRequest, UserChatMessagesRequest, UserImageChatRequest)
+        ):
             if not hasattr(req, "model") or not req.model:
                 raise ValueError("Chat request missing required 'model' field")
-            if not hasattr(req, "prompt") and not isinstance(req, UserImageChatRequest):
+            if isinstance(req, UserChatMessagesRequest):
+                if not hasattr(req, "messages") or not req.messages:
+                    raise ValueError(
+                        "Chat messages request missing required 'messages' field"
+                    )
+            elif not hasattr(req, "prompt") and not isinstance(
+                req, UserImageChatRequest
+            ):
                 raise ValueError("Chat request missing required 'prompt' field")
         elif isinstance(req, UserEmbeddingRequest):
             if not hasattr(req, "model") or not req.model:
@@ -179,7 +193,7 @@ class BaseAsyncRunner:
         else:
             raise ValueError(
                 f"Unsupported request type: {type(req)}. "
-                f"Expected UserChatRequest, UserImageChatRequest, or UserEmbeddingRequest."
+                f"Expected UserChatRequest, UserChatMessagesRequest, UserImageChatRequest, or UserEmbeddingRequest."
             )
 
         return req
@@ -240,7 +254,9 @@ class BaseAsyncRunner:
         """Send a request and return the response. Handles streaming for chat completions."""
         # Currently implement OpenAI-compatible endpoints for text chat and embeddings
         try:
-            if isinstance(req, (UserChatRequest, UserImageChatRequest)):
+            if isinstance(
+                req, (UserChatRequest, UserChatMessagesRequest, UserImageChatRequest)
+            ):
                 endpoint = "/v1/chat/completions"
                 if isinstance(req, UserImageChatRequest):
                     text_content = [{"type": "text", "text": req.prompt}]  # type: ignore[attr-defined]
@@ -248,9 +264,15 @@ class BaseAsyncRunner:
                         {"type": "image_url", "image_url": {"url": image}}  # type: ignore[attr-defined]
                         for image in req.image_content  # type: ignore[attr-defined]
                     ]
-                    content = text_content + image_content  # type: ignore[assignment]
+                    messages = [
+                        {"role": "user", "content": text_content + image_content}
+                    ]  # type: ignore[assignment]
+                elif isinstance(req, UserChatMessagesRequest):
+                    # Use the messages field directly for message-based requests
+                    messages = req.messages  # type: ignore[assignment]
                 else:
-                    content = req.prompt  # type: ignore[assignment]
+                    # Regular UserChatRequest - wrap prompt in user message
+                    messages = [{"role": "user", "content": req.prompt}]  # type: ignore[assignment]
 
                 # Build payload - prioritize max_tokens from additional_request_params if present
                 # min_tokens and max_tokens are now automatically set by the sampler from the scenario
@@ -261,12 +283,7 @@ class BaseAsyncRunner:
 
                 payload = {
                     "model": req.model,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": content,
-                        }
-                    ],
+                    "messages": messages,
                     "max_tokens": max_tokens,
                     "temperature": req.additional_request_params.get(
                         "temperature", 0.0
@@ -284,17 +301,14 @@ class BaseAsyncRunner:
                     },
                 }
 
-                # For Baseten, api_base already includes the full endpoint path
+                # For Baseten, append the endpoint to the base URL
                 # For other backends, append the endpoint to the base URL
-                if self.api_backend.lower() == "baseten":
-                    request_url = self.api_base
-                else:
-                    request_url = f"{self.api_base}{endpoint}"
+                request_url = f"{self.api_base}{endpoint}"
 
                 # Log first request for debugging
                 if not hasattr(self, "_logged_request_info"):
-                    logger.info(f"🌐 Async runner request URL: {request_url}")
-                    logger.info(f"🔑 Headers present: {bool(self.headers)}")
+                    logger.info(f"Async runner request URL: {request_url}")
+                    logger.info(f"Headers present: {bool(self.headers)}")
                     if self.headers:
                         auth_header = self.headers.get("Authorization", "None")
                         # Mask the API key for security
@@ -302,7 +316,7 @@ class BaseAsyncRunner:
                             parts = auth_header.split(" ", 1)
                             if len(parts) == 2:
                                 auth_header = f"{parts[0]} [REDACTED]"
-                        logger.info(f"🔐 Auth header: {auth_header}")
+                        logger.info(f"Auth header: {auth_header}")
                     self._logged_request_info = True
 
                 start_time = time.monotonic()
@@ -503,12 +517,9 @@ class BaseAsyncRunner:
                     "input": req.documents,
                     **req.additional_request_params,
                 }
-                # For Baseten, api_base already includes the full endpoint path
+                # For Baseten, append the endpoint to the base URL
                 # For other backends, append the endpoint to the base URL
-                if self.api_backend.lower() == "baseten":
-                    request_url = self.api_base
-                else:
-                    request_url = f"{self.api_base}{endpoint}"
+                request_url = f"{self.api_base}{endpoint}"
 
                 start_time = time.monotonic()
                 # Reuse session if available, otherwise create new one

--- a/genai_bench/cli/cli.py
+++ b/genai_bench/cli/cli.py
@@ -5,6 +5,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Any, Dict
 
 import click
 
@@ -70,7 +71,7 @@ def cli(ctx):
 @storage_auth_options
 @click.pass_context
 def benchmark(
-    ctx,
+    ctx: click.Context,
     api_backend,
     api_base,
     api_key,
@@ -122,6 +123,7 @@ def benchmark(
     dataset_config,
     dataset_prompt_column,
     dataset_image_column,
+    dataset_message_format,
     num_workers,
     master_port,
     spawn_rate,
@@ -151,10 +153,8 @@ def benchmark(
     github_owner,
     github_repo,
     metrics_time_unit,
-):
-    """
-    Run a benchmark based on user defined scenarios.
-    """
+) -> None:
+    """Run a benchmark based on user defined scenarios."""
     # Set up the dashboard and layout
     dashboard = create_dashboard(metrics_time_unit)
 
@@ -350,6 +350,7 @@ def benchmark(
             dataset_path=dataset_path,
             prompt_column=dataset_prompt_column,
             image_column=dataset_image_column,
+            message_format=dataset_message_format,
         )
 
     # Load data using the factory
@@ -543,9 +544,9 @@ def benchmark(
                     sanitized_scenario_str = sanitize_string(scenario_str)
 
                     # Store metrics for current scenario for interim plot
-                    scenario_metrics = {
+                    scenario_metrics: Dict[str, Any] = {
                         "data": {},
-                        f"{iteration_type_display}": [],
+                        "iterations": [],
                     }
 
                     # Reset prefix cache for new scenario
@@ -678,7 +679,7 @@ def benchmark(
                         scenario_metrics["data"][iteration] = {
                             "aggregated_metrics": aggregated_metrics_collector.aggregated_metrics
                         }
-                        scenario_metrics[f"{iteration_type_display}"].append(iteration)
+                        scenario_metrics["iterations"].append(iteration)
                         aggregated_metrics_collector.clear()
 
                         dashboard.update_total_progress_bars(total_runs)
@@ -795,7 +796,7 @@ def benchmark(
             storage = StorageFactory.create_storage(
                 storage_provider_final, storage_auth_provider, **storage_kwargs
             )
-            storage.upload_directory(
+            storage.upload_folder(
                 experiment_folder_abs_path,
                 storage_bucket_final,
                 storage_prefix_final,
@@ -810,7 +811,7 @@ def benchmark(
     environment = Environment(user_classes=[user_class])
     # Assign the selected task to the user class
     environment.user_classes[0].tasks = [user_task]
-    environment.sampler = sampler
+    environment.sampler = sampler  # type: ignore[attr-defined]
 
     # Set up distributed runner
     config = DistributedConfig(
@@ -866,7 +867,7 @@ def benchmark(
                 # Store metrics for current scenario for interim plot
                 scenario_metrics = {
                     "data": {},
-                    f"{iteration_type}": [],
+                    "iterations": [],
                 }
 
                 for iteration in iteration_values:
@@ -958,7 +959,7 @@ def benchmark(
                     scenario_metrics["data"][iteration] = {
                         "aggregated_metrics": aggregated_metrics_collector.aggregated_metrics  # noqa: E501
                     }
-                    scenario_metrics[f"{iteration_type}"].append(iteration)
+                    scenario_metrics["iterations"].append(iteration)
 
                     aggregated_metrics_collector.clear()
 

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -322,6 +322,16 @@ def sampling_options(func):
         "check out DatasetConfig.",
     )(func)
     func = click.option(
+        "--dataset-message-format",
+        type=click.Choice(["openai"], case_sensitive=False),
+        default=None,
+        help="Format for message-based datasets. Use 'openai' for datasets with "
+        "message lists in OpenAI chat format (e.g., [{'role': 'user', 'content': '...'}]). "
+        "Required when using message lists from HuggingFace datasets like "
+        "baseten/gamma_paste_text_benchmarking. Example:\n"
+        "--dataset-message-format openai --dataset-prompt-column messages",
+    )(func)
+    func = click.option(
         "--dataset-path",
         type=str,
         callback=validate_dataset_path_callback,

--- a/genai_bench/data/config.py
+++ b/genai_bench/data/config.py
@@ -65,6 +65,10 @@ class DatasetConfig(BaseModel):
         description="Lambda expression string, "
         'e.g. \'lambda item: f"Question: {item["question"]}"\'',
     )
+    message_format: Optional[str] = Field(
+        None,
+        description="Format for message-based datasets. Currently supports 'openai' for OpenAI chat format.",
+    )
     unsafe_allow_large_images: bool = Field(
         False,
         description="Overrides pillows internal DDOS protection",
@@ -83,6 +87,7 @@ class DatasetConfig(BaseModel):
         dataset_path: Optional[str] = None,
         prompt_column: Optional[str] = None,
         image_column: Optional[str] = None,
+        message_format: Optional[str] = None,
         **kwargs,
     ) -> "DatasetConfig":
         """Create configuration from CLI arguments for backward compatibility."""
@@ -111,6 +116,11 @@ class DatasetConfig(BaseModel):
                     f"Unsupported file format: {path.suffix}. "
                     f"Supported formats: {', '.join(supported_extensions)}"
                 )
+            elif "/" in dataset_path and not path.exists():
+                # Contains a slash (like HuggingFace dataset IDs) and doesn't exist locally
+                # Treat as HuggingFace dataset ID
+                source_type = "huggingface"
+                file_format = None
             else:
                 # No file extension and doesn't exist - assume it's a HuggingFace ID
                 source_type = "huggingface"
@@ -120,7 +130,9 @@ class DatasetConfig(BaseModel):
             type=source_type,
             path=dataset_path,
             file_format=file_format,
-            huggingface_kwargs=None,
+            huggingface_kwargs={"split": "train"}
+            if source_type == "huggingface"
+            else None,
             loader_class=None,
             loader_kwargs=None,
         )
@@ -130,5 +142,6 @@ class DatasetConfig(BaseModel):
             prompt_column=prompt_column,
             image_column=image_column,
             prompt_lambda=None,
+            message_format=message_format,
             unsafe_allow_large_images=False,
         )

--- a/genai_bench/data/loaders/base.py
+++ b/genai_bench/data/loaders/base.py
@@ -64,7 +64,7 @@ class DatasetLoader(ABC):
                     f"{self.media_type} loader."
                 )
 
-    def load_request(self) -> Union[List[str], List[Tuple[str, Any]]]:
+    def load_request(self) -> Union[List[str], List[Tuple[str, Any]], List[List[dict]]]:
         """Load data from the dataset source."""
         self._disable_pillow_decompresion_check()
         data = self.dataset_source.load()
@@ -73,7 +73,7 @@ class DatasetLoader(ABC):
     @abstractmethod
     def _process_loaded_data(
         self, data: Any
-    ) -> Union[List[str], List[Tuple[str, Any]]]:
+    ) -> Union[List[str], List[Tuple[str, Any]], List[List[dict]]]:
         """
         Process data loaded from dataset source. Must be implemented by subclasses.
         """

--- a/genai_bench/data/loaders/text.py
+++ b/genai_bench/data/loaders/text.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Set
+from typing import Any, List, Set, Tuple, Union
 
 from genai_bench.data.loaders.base import DatasetFormat, DatasetLoader
 from genai_bench.logging import init_logger
@@ -21,16 +21,42 @@ class TextDatasetLoader(DatasetLoader):
     }
     media_type = "Text"
 
-    def _process_loaded_data(self, data: Any) -> List[str]:
+    def _process_loaded_data(
+        self, data: Any
+    ) -> Union[List[str], List[Tuple[str, Any]], List[List[dict]]]:
         """Process data loaded from dataset source."""
         # Handle data from dataset sources
         if isinstance(data, list):
-            return data
+            # Check if this is a list of message lists
+            if (
+                data
+                and isinstance(data[0], list)
+                and self.dataset_config.message_format == "openai"
+            ):
+                # Return raw message lists for TextSampler
+                return data
+            return data  # Return as-is for string lists
 
         # Handle dictionary data (from CSV files) or HuggingFace datasets
         prompt_column = self.dataset_config.prompt_column
+        message_format = self.dataset_config.message_format
+
         try:
             column_data = data[prompt_column]
+
+            # Check if we have message lists and message_format is specified
+            if (
+                message_format == "openai"
+                and isinstance(column_data, list)
+                and column_data
+                and isinstance(column_data[0], list)
+            ):
+                # We have message lists
+                logger.info(f"Detected message lists in column '{prompt_column}'")
+                validated = self._validate_message_lists(column_data)
+                # Return raw message lists for TextSampler
+                return validated
+
             # Ensure we return a list of strings
             if isinstance(column_data, list):
                 return [str(item) for item in column_data]
@@ -49,3 +75,67 @@ class TextDatasetLoader(DatasetLoader):
                 raise ValueError(
                     f"Cannot extract prompts from data: {type(data)}, error: {str(e)}"
                 ) from e
+
+    def _validate_message_lists(
+        self, message_lists: List[List[dict]]
+    ) -> List[List[dict]]:
+        """Validate that message lists are in proper OpenAI format."""
+        if not message_lists:
+            raise ValueError(
+                "Message lists column is empty. Please check your dataset."
+            )
+
+        validated = []
+        for i, messages in enumerate(message_lists):
+            if not isinstance(messages, list):
+                raise ValueError(
+                    f"Message list at index {i} is not a list (found {type(messages).__name__}). "
+                    f"Expected a list of message dictionaries."
+                )
+
+            if not messages:
+                raise ValueError(
+                    f"Message list at index {i} is empty. Each message list must contain at least one message."
+                )
+
+            # Validate each message
+            for j, message in enumerate(messages):
+                if not isinstance(message, dict):
+                    raise ValueError(
+                        f"Message at index {i}[{j}] is not a dictionary (found {type(message).__name__}). "
+                        f"Expected a dict with 'role' and 'content' fields."
+                    )
+
+                if "role" not in message:
+                    raise ValueError(
+                        f"Message at index {i}[{j}] is missing required 'role' field. "
+                        f"Available fields: {list(message.keys())}"
+                    )
+
+                if "content" not in message:
+                    raise ValueError(
+                        f"Message at index {i}[{j}] is missing required 'content' field. "
+                        f"Available fields: {list(message.keys())}"
+                    )
+
+                role = message["role"]
+                if role not in ["system", "user", "assistant"]:
+                    raise ValueError(
+                        f"Invalid message role '{role}' at index {i}[{j}]. "
+                        f"Supported roles: system, user, assistant"
+                    )
+
+                content = message["content"]
+                if not isinstance(content, str):
+                    raise ValueError(
+                        f"Message content at index {i}[{j}] must be a string (found {type(content).__name__})."
+                    )
+
+                if not content.strip():
+                    raise ValueError(
+                        f"Message content at index {i}[{j}] cannot be empty or whitespace only."
+                    )
+
+            validated.append(messages)
+
+        return validated

--- a/genai_bench/protocol.py
+++ b/genai_bench/protocol.py
@@ -31,6 +31,21 @@ class UserChatRequest(UserRequest):
     )
 
 
+class UserChatMessagesRequest(UserChatRequest):
+    """
+    A class to encapsulate chat request tasks using message lists (OpenAI chat format).
+    This extends UserChatRequest to maintain backward compatibility while adding
+    support for structured message lists.
+    """
+
+    messages: List[Dict[str, str]] = Field(
+        ..., description="List of messages in OpenAI chat format."
+    )
+    prompt: Optional[str] = Field(
+        None, description="Not used for message-based requests. Kept for compatibility."
+    )
+
+
 class UserImageChatRequest(UserChatRequest):
     """
     Represents a request that combines image and chat modalities, used for tasks

--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -1,9 +1,10 @@
 import random
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from genai_bench.data.config import DatasetConfig
 from genai_bench.logging import init_logger
 from genai_bench.protocol import (
+    UserChatMessagesRequest,
     UserChatRequest,
     UserEmbeddingRequest,
     UserRequest,
@@ -30,7 +31,7 @@ class TextSampler(Sampler):
         tokenizer,
         model: str,
         output_modality: str,
-        data: List[str],
+        data: List[Union[str, List[dict]]],
         additional_request_params: Optional[Dict[str, Any]] = None,
         dataset_config: Optional[DatasetConfig] = None,
         **kwargs,
@@ -67,8 +68,15 @@ class TextSampler(Sampler):
         else:
             raise ValueError(f"Unsupported output modality: {self.output_modality}")
 
-    def _sample_chat_request(self, scenario: Optional[Scenario]) -> UserChatRequest:
+    def _sample_chat_request(
+        self, scenario: Optional[Scenario]
+    ) -> Union[UserChatRequest, UserChatMessagesRequest]:
         """Samples a chat request based on the scenario."""
+        # Check if we have message lists
+        if self._has_message_lists():
+            return self._sample_chat_messages_request(scenario)
+
+        # Original string-based logic
         if self._is_dataset_mode(scenario):
             # Use dataset-mode sampling
             num_input_tokens, num_output_tokens = None, None
@@ -123,7 +131,7 @@ class TextSampler(Sampler):
         documents = [
             self._sample_text(tokens_per_document) for _ in range(self.batch_size)
         ]
-        num_prefill_tokens = sum(self.get_token_length(doc) for doc in documents)
+        num_prefill_tokens = sum([self.get_token_length(str(doc)) for doc in documents])
         if tokens_per_document is not None:
             num_expected_tokens = tokens_per_document * self.batch_size
             self._check_discrepancy(num_expected_tokens, num_prefill_tokens, 0.2)
@@ -149,7 +157,7 @@ class TextSampler(Sampler):
             self._sample_text(tokens_per_document) for _ in range(self.batch_size)
         ]
         num_prefill_tokens = sum(
-            self.get_token_length(doc) for doc in documents
+            [self.get_token_length(str(doc)) for doc in documents]
         ) + self.get_token_length(query)
 
         return UserReRankRequest(
@@ -172,6 +180,10 @@ class TextSampler(Sampler):
         if scenario is None:
             raise ValueError("A scenario is required when using the default dataset.")
 
+        # Skip validation if we're using message lists (dataset mode)
+        if self._has_message_lists():
+            return
+
         if self.output_modality == "text" and not isinstance(
             scenario.scenario_type, TextDistribution
         ):
@@ -187,7 +199,7 @@ class TextSampler(Sampler):
                 f"{type(scenario.scenario_type)}"
             )
 
-    def _sample_text(self, num_input_tokens: Optional[int]) -> str:
+    def _sample_text(self, num_input_tokens: Optional[int]) -> Union[str, List[dict]]:
         """
         Samples text from a list of lines based on the specified number of
         input tokens. If num_input_tokens is None, samples a random line
@@ -197,18 +209,26 @@ class TextSampler(Sampler):
             num_input_tokens (int): The target number of input tokens.
 
         Returns:
-            str: A text prompt containing the desired number of tokens.
+            Union[str, List[dict]]: A text prompt or message list containing the desired number of tokens.
         """
         if not num_input_tokens:
             return random.choice(self.data)
 
+        # Handle message lists differently
+        if self._has_message_lists():
+            # For message lists, we don't concatenate - just return one
+            return random.choice(self.data)
+
         data_copy = self.data.copy()
-        prompt = ""
+        prompt: str = ""
         left_tokens_to_sample = num_input_tokens
 
         while left_tokens_to_sample > 0:
             random.shuffle(data_copy)
             for line in data_copy:
+                # Skip message lists in string concatenation mode
+                if isinstance(line, list):
+                    continue
                 # Tokenize line with space prefix to match how it will be concatenated
                 line_with_space = (" " if prompt else "") + line
                 line_tokens = self.tokenizer.encode(
@@ -239,8 +259,10 @@ class TextSampler(Sampler):
                     return prompt
 
                 # Add line with space separator (consistent with truncated text handling)
-                prompt += (" " if prompt else "") + line
-                left_tokens_to_sample -= num_line_tokens
+                # Skip message lists
+                if not isinstance(line, list):
+                    prompt += (" " if prompt else "") + line
+                    left_tokens_to_sample -= num_line_tokens
         return prompt
 
     def _check_discrepancy(
@@ -289,6 +311,12 @@ class TextSampler(Sampler):
         if cache_key not in self._shared_prefix_cache:
             # Generate the shared prefix once
             prefix = self._sample_text(prefix_len)
+            # Ensure prefix is a string for caching
+            if isinstance(prefix, list):
+                # Convert message list to string for caching
+                prefix = "\n".join(
+                    [f"{msg['role']}: {msg['content']}" for msg in prefix]
+                )
             self._shared_prefix_cache[cache_key] = prefix
 
             # Calculate hash for verification
@@ -381,6 +409,93 @@ class TextSampler(Sampler):
             max_tokens=output_len,
             additional_request_params=self.additional_request_params,
         )
+
+    def _has_message_lists(self) -> bool:
+        """Check if the data contains message lists instead of strings."""
+        if not self.data:
+            return False
+
+        # Check if the first item is a list (message list)
+        first_item = self.data[0]
+        return isinstance(first_item, list)
+
+    def _sample_chat_messages_request(
+        self, scenario: Optional[Scenario]
+    ) -> UserChatMessagesRequest:
+        """Samples a chat request using message lists."""
+        if self._is_dataset_mode(scenario):
+            # Use dataset-mode sampling
+            num_input_tokens, num_output_tokens = None, None
+            # Only set ignore_eos to False if not already specified by user
+            if "ignore_eos" not in self.additional_request_params:
+                self.additional_request_params["ignore_eos"] = False
+        else:
+            # Use scenario-based sampling
+            self._validate_scenario(scenario)
+            num_input_tokens, num_output_tokens = scenario.sample()
+            self.additional_request_params["ignore_eos"] = True
+
+        # Sample a message list from the data
+        messages = random.choice(self.data)
+
+        # Calculate token count for messages
+        num_prefill_tokens = self._count_message_tokens(messages)
+
+        if num_input_tokens is not None:
+            self._check_discrepancy(num_input_tokens, num_prefill_tokens, threshold=0.1)
+
+        # Set min_tokens and max_tokens from scenario's desired output
+        if num_output_tokens is not None:
+            self.additional_request_params["min_tokens"] = num_output_tokens
+            self.additional_request_params["max_tokens"] = num_output_tokens
+
+        return UserChatMessagesRequest(
+            model=self.model,
+            prompt=None,  # Not used when messages are provided
+            messages=messages,
+            num_prefill_tokens=num_prefill_tokens,
+            max_tokens=num_output_tokens,
+            additional_request_params=self.additional_request_params,
+        )
+
+    def _count_message_tokens(self, messages: List[dict]) -> int:
+        """Count tokens in a list of messages using the actual tokenizer."""
+        if not self.tokenizer:
+            # Fallback to character-based approximation if no tokenizer
+            total_chars = sum(
+                len(msg.get("content", "")) + len(msg.get("role", "")) + 10
+                for msg in messages
+            )
+            return max(1, total_chars // 4)
+
+        total_tokens = 0
+
+        for message in messages:
+            content = message.get("content", "")
+            role = message.get("role", "")
+
+            # Count tokens for the message with chat format
+            # Include special tokens for role formatting
+            # Format: <|im_start|>user\n<content><|im_end|>
+
+            # Count special tokens for chat format
+            # <|im_start|>, <|im_end|>, newlines
+            # This varies by tokenizer, so we'll encode the full format
+            formatted_message = f"<|im_start|>{role}\n{content}<|im_end|>"
+            full_tokens = self.tokenizer.encode(
+                formatted_message, add_special_tokens=False
+            )
+
+            total_tokens += len(full_tokens)
+
+        # Add final assistant message starter if not present
+        if messages and messages[-1].get("role") != "assistant":
+            final_tokens = self.tokenizer.encode(
+                "<|im_start|>assistant\n", add_special_tokens=False
+            )
+            total_tokens += len(final_tokens)
+
+        return max(1, total_tokens)
 
     def reset_prefix_cache(self):
         """Clear the prefix cache and reset counter.

--- a/genai_bench/user/openai_user.py
+++ b/genai_bench/user/openai_user.py
@@ -13,6 +13,7 @@ from requests import Response
 from genai_bench.auth.model_auth_provider import ModelAuthProvider
 from genai_bench.logging import init_logger
 from genai_bench.protocol import (
+    UserChatMessagesRequest,
     UserChatRequest,
     UserChatResponse,
     UserEmbeddingRequest,
@@ -54,14 +55,19 @@ class OpenAIUser(BaseUser):
         endpoint = "/v1/chat/completions"
         user_request = self.sample()
 
-        if not isinstance(user_request, UserChatRequest):
+        if not isinstance(user_request, (UserChatRequest, UserChatMessagesRequest)):
             raise AttributeError(
                 f"user_request should be of type "
-                f"UserChatRequest for OpenAIUser.chat, got "
+                f"UserChatRequest or UserChatMessagesRequest for OpenAIUser.chat, got "
                 f"{type(user_request)}"
             )
 
-        if isinstance(user_request, UserImageChatRequest):
+        # Handle different request types
+        if isinstance(user_request, UserChatMessagesRequest):
+            # Use messages directly from the request
+            messages = user_request.messages
+        elif isinstance(user_request, UserImageChatRequest):
+            # Handle image chat requests
             text_content = [{"type": "text", "text": user_request.prompt}]
             image_content = [
                 {
@@ -70,21 +76,27 @@ class OpenAIUser(BaseUser):
                 }
                 for image in user_request.image_content
             ]
-            content = text_content + image_content
+            messages = [
+                {
+                    "role": "user",
+                    "content": text_content + image_content,
+                }
+            ]
         else:
+            # Backward compatibility for string-based prompts
             # Backward compatibility for vLLM versions prior to v0.5.1.
             # OpenAI API used a different text prompt format before
             # multi-modality model support.
-            content = user_request.prompt
+            messages = [
+                {
+                    "role": "user",
+                    "content": user_request.prompt,
+                }
+            ]
 
         payload = {
             "model": user_request.model,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": content,
-                }
-            ],
+            "messages": messages,
             "max_tokens": user_request.max_tokens,
             "temperature": user_request.additional_request_params.get(
                 "temperature", 0.0

--- a/tests/async_runner/test_network_timing.py
+++ b/tests/async_runner/test_network_timing.py
@@ -1,7 +1,8 @@
 """Tests for network timing functionality in the async runner."""
 
-import pytest
 import time
+
+import pytest
 
 from genai_bench.async_runner.base import NetworkTimingContext, create_trace_config
 

--- a/tests/sampling/test_message_lists.py
+++ b/tests/sampling/test_message_lists.py
@@ -1,0 +1,618 @@
+"""Tests for message list support in text sampling."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from genai_bench.data.config import DatasetConfig
+from genai_bench.data.loaders.text import TextDatasetLoader
+from genai_bench.protocol import UserChatMessagesRequest, UserChatRequest
+from genai_bench.sampling.text import TextSampler
+
+
+# -- Fixtures --
+
+
+@pytest.fixture
+def sample_message_lists():
+    """Reusable message list data."""
+    return [
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello!"},
+        ],
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "How are you?"},
+        ],
+    ]
+
+
+@pytest.fixture
+def mock_tokenizer():
+    """Mock tokenizer that returns predictable token counts."""
+    tokenizer = Mock()
+    tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+    return tokenizer
+
+
+@pytest.fixture
+def message_sampler(sample_message_lists, mock_tokenizer):
+    """TextSampler configured for message lists."""
+    return TextSampler(
+        tokenizer=mock_tokenizer,
+        model="test-model",
+        output_modality="text",
+        data=sample_message_lists,
+        dataset_config=DatasetConfig.from_cli_args(message_format="openai"),
+    )
+
+
+# -- DatasetConfig Tests --
+
+
+class TestDatasetConfigMessageFormat:
+    """Test DatasetConfig with message_format."""
+
+    def test_config_with_message_format(self):
+        config = DatasetConfig.from_cli_args(
+            dataset_path="test.json", message_format="openai"
+        )
+        assert config.message_format == "openai"
+        assert config.source.type == "file"
+        assert config.source.file_format == "json"
+
+    def test_config_without_message_format(self):
+        config = DatasetConfig.from_cli_args(dataset_path="test.json")
+        assert config.message_format is None
+
+    def test_config_huggingface_with_slash(self):
+        """HuggingFace IDs with slashes should be detected correctly."""
+        config = DatasetConfig.from_cli_args(
+            dataset_path="baseten/gamma_paste_text_benchmarking",
+            message_format="openai",
+            prompt_column="messages",
+        )
+        assert config.source.type == "huggingface"
+        assert config.message_format == "openai"
+        assert config.prompt_column == "messages"
+        assert config.source.huggingface_kwargs == {"split": "train"}
+
+
+# -- TextDatasetLoader Tests --
+
+
+class TestTextDatasetLoaderMessages:
+    """Test TextDatasetLoader with message list data."""
+
+    def test_load_message_list_from_json(self, sample_message_lists):
+        """Test loading message lists from a JSON file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sample_message_lists, f)
+            temp_path = f.name
+
+        try:
+            config = DatasetConfig.from_cli_args(
+                dataset_path=temp_path, message_format="openai"
+            )
+            loader = TextDatasetLoader(config)
+            data = loader.load_request()
+
+            assert len(data) == 2
+            assert isinstance(data[0], list)
+            assert data[0][0]["role"] == "system"
+        finally:
+            Path(temp_path).unlink()
+
+    def test_process_dict_data_with_message_lists(self, sample_message_lists):
+        """Test _process_loaded_data with dict-shaped data (like HuggingFace)."""
+        config = DatasetConfig.from_cli_args(
+            message_format="openai", prompt_column="messages"
+        )
+        loader = TextDatasetLoader(config)
+        dict_data = {"messages": sample_message_lists}
+
+        result = loader._process_loaded_data(dict_data)
+        assert len(result) == 2
+        assert isinstance(result[0], list)
+
+    def test_process_list_of_lists_with_message_format(self, sample_message_lists):
+        """Test _process_loaded_data with a flat list of message lists."""
+        config = DatasetConfig.from_cli_args(message_format="openai")
+        loader = TextDatasetLoader(config)
+
+        result = loader._process_loaded_data(sample_message_lists)
+        assert len(result) == 2
+        assert isinstance(result[0], list)
+
+    def test_process_string_data_unchanged(self):
+        """Test that string data still works with message_format set."""
+        config = DatasetConfig.from_cli_args(message_format="openai")
+        loader = TextDatasetLoader(config)
+        string_data = ["Hello", "World"]
+
+        result = loader._process_loaded_data(string_data)
+        assert result == ["Hello", "World"]
+
+    def test_validate_message_lists_valid(self):
+        """Test validation passes for well-formed message lists."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        messages = [
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello!"},
+            ]
+        ]
+        result = loader._validate_message_lists(messages)
+        assert len(result) == 1
+
+    def test_validate_message_lists_missing_role(self):
+        """Test validation fails when role is missing."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="missing required 'role' field"):
+            loader._validate_message_lists([[{"content": "No role"}]])
+
+    def test_validate_message_lists_missing_content(self):
+        """Test validation fails when content is missing."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="missing required 'content' field"):
+            loader._validate_message_lists([[{"role": "user"}]])
+
+    def test_validate_message_lists_invalid_role(self):
+        """Test validation fails for unsupported roles."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="Invalid message role 'admin'"):
+            loader._validate_message_lists([[{"role": "admin", "content": "Bad role"}]])
+
+    def test_validate_message_lists_empty_content(self):
+        """Test validation fails for empty/whitespace content."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="cannot be empty or whitespace only"):
+            loader._validate_message_lists([[{"role": "user", "content": "   "}]])
+
+    def test_validate_message_lists_empty_list(self):
+        """Test validation fails for empty message list."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="column is empty"):
+            loader._validate_message_lists([])
+
+    def test_validate_message_lists_empty_inner_list(self):
+        """Test validation fails for empty inner message list."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="is empty"):
+            loader._validate_message_lists([[]])
+
+    def test_validate_message_lists_non_dict_message(self):
+        """Test validation fails when message is not a dict."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="is not a dictionary"):
+            loader._validate_message_lists([["not a dict"]])
+
+    def test_validate_message_lists_non_list_inner(self):
+        """Test validation fails when inner item is not a list."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="is not a list"):
+            loader._validate_message_lists(["not a list"])
+
+    def test_validate_message_lists_non_string_content(self):
+        """Test validation fails when content is not a string."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        with pytest.raises(ValueError, match="must be a string"):
+            loader._validate_message_lists([[{"role": "user", "content": 123}]])
+
+    def test_validate_message_lists_all_roles(self):
+        """Test validation accepts all valid roles."""
+        loader = TextDatasetLoader(DatasetConfig.from_cli_args(message_format="openai"))
+        messages = [
+            [
+                {"role": "system", "content": "System prompt."},
+                {"role": "user", "content": "User message."},
+                {"role": "assistant", "content": "Assistant response."},
+            ]
+        ]
+        result = loader._validate_message_lists(messages)
+        assert len(result) == 1
+        assert len(result[0]) == 3
+
+
+# -- TextSampler Tests --
+
+
+class TestTextSamplerMessageLists:
+    """Test TextSampler with message list data."""
+
+    def test_has_message_lists_true(self, message_sampler):
+        assert message_sampler._has_message_lists()
+
+    def test_has_message_lists_false_with_strings(self, mock_tokenizer):
+        sampler = TextSampler(
+            tokenizer=mock_tokenizer,
+            model="test-model",
+            output_modality="text",
+            data=["Hello", "World"],
+            dataset_config=DatasetConfig.from_cli_args(),
+        )
+        assert not sampler._has_message_lists()
+
+    def test_has_message_lists_false_with_empty(self, mock_tokenizer):
+        sampler = TextSampler(
+            tokenizer=mock_tokenizer,
+            model="test-model",
+            output_modality="text",
+            data=[],
+            dataset_config=DatasetConfig.from_cli_args(),
+        )
+        assert not sampler._has_message_lists()
+
+    def test_sample_returns_message_request(self, message_sampler):
+        request = message_sampler.sample(scenario=None)
+        assert isinstance(request, UserChatMessagesRequest)
+
+    def test_sample_message_request_fields(self, message_sampler):
+        request = message_sampler.sample(scenario=None)
+        assert request.model == "test-model"
+        assert request.messages is not None
+        assert len(request.messages) >= 1
+        assert all("role" in msg for msg in request.messages)
+        assert all("content" in msg for msg in request.messages)
+
+    def test_sample_message_request_num_prefill_tokens(self, message_sampler):
+        request = message_sampler.sample(scenario=None)
+        assert request.num_prefill_tokens is not None
+        assert request.num_prefill_tokens > 0
+
+    def test_sample_message_request_ignore_eos_default(self, message_sampler):
+        """In dataset mode (no scenario), ignore_eos should be False."""
+        request = message_sampler.sample(scenario=None)
+        assert request.additional_request_params.get("ignore_eos") is False
+
+    def test_count_message_tokens_with_tokenizer(self, mock_tokenizer):
+        sampler = TextSampler(
+            tokenizer=mock_tokenizer,
+            model="test-model",
+            output_modality="text",
+            data=[],
+            dataset_config=DatasetConfig.from_cli_args(message_format="openai"),
+        )
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello!"},
+        ]
+
+        count = sampler._count_message_tokens(messages)
+        assert count > 0
+        assert isinstance(count, int)
+
+    def test_count_message_tokens_without_tokenizer(self):
+        """Test fallback char-based estimation when no tokenizer."""
+        sampler = TextSampler(
+            tokenizer=None,
+            model="test-model",
+            output_modality="text",
+            data=[],
+            dataset_config=DatasetConfig.from_cli_args(message_format="openai"),
+        )
+
+        messages = [
+            {"role": "user", "content": "Hello world, this is a test."},
+        ]
+
+        count = sampler._count_message_tokens(messages)
+        assert count > 0
+
+    def test_count_message_tokens_adds_assistant_starter(self, mock_tokenizer):
+        """Token count should include assistant turn starter when last msg is user."""
+        sampler = TextSampler(
+            tokenizer=mock_tokenizer,
+            model="test-model",
+            output_modality="text",
+            data=[],
+            dataset_config=DatasetConfig.from_cli_args(message_format="openai"),
+        )
+
+        # Last message is user - should add assistant starter tokens
+        messages_user = [{"role": "user", "content": "Hello!"}]
+        count_user = sampler._count_message_tokens(messages_user)
+
+        # Last message is assistant - should NOT add assistant starter tokens
+        messages_asst = [{"role": "assistant", "content": "Hi there!"}]
+        count_asst = sampler._count_message_tokens(messages_asst)
+
+        # Both should be positive
+        assert count_user > 0
+        assert count_asst > 0
+
+    def test_backward_compatibility_string_data(self, mock_tokenizer):
+        """String-based prompts should still produce UserChatRequest."""
+        mock_tokenizer.__len__ = Mock(return_value=3)
+        sampler = TextSampler(
+            tokenizer=mock_tokenizer,
+            model="test-model",
+            output_modality="text",
+            data=["Hello world", "How are you?"],
+            dataset_config=DatasetConfig.from_cli_args(),
+        )
+
+        request = sampler.sample(scenario=None)
+        assert isinstance(request, UserChatRequest)
+        assert not isinstance(request, UserChatMessagesRequest)
+        assert isinstance(request.prompt, str)
+
+
+# -- UserChatMessagesRequest Protocol Tests --
+
+
+class TestUserChatMessagesRequest:
+    """Test the UserChatMessagesRequest protocol model."""
+
+    def test_create_valid_request(self):
+        request = UserChatMessagesRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            num_prefill_tokens=5,
+            max_tokens=10,
+        )
+        assert request.model == "test-model"
+        assert request.messages == [{"role": "user", "content": "Hello"}]
+        assert request.prompt is None  # Default for message requests
+        assert request.num_prefill_tokens == 5
+
+    def test_inherits_from_user_chat_request(self):
+        request = UserChatMessagesRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            num_prefill_tokens=5,
+            max_tokens=10,
+        )
+        assert isinstance(request, UserChatRequest)
+
+    def test_prompt_is_optional(self):
+        request = UserChatMessagesRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            num_prefill_tokens=5,
+            max_tokens=10,
+        )
+        assert request.prompt is None
+
+    def test_multi_turn_messages(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+            {"role": "user", "content": "And 3+3?"},
+        ]
+        request = UserChatMessagesRequest(
+            model="test-model",
+            messages=messages,
+            num_prefill_tokens=20,
+            max_tokens=10,
+        )
+        assert len(request.messages) == 4
+
+
+# -- OpenAI User Tests --
+
+
+class TestOpenAIUserMessageLists:
+    """Test OpenAI user with message list requests."""
+
+    @patch("genai_bench.user.openai_user.requests.post")
+    def test_chat_with_message_list_request(self, mock_post):
+        """Test that OpenAIUser.chat sends messages correctly."""
+        from genai_bench.user.openai_user import OpenAIUser
+
+        mock_auth = MagicMock()
+        mock_auth.get_credentials.return_value = "fake_api_key"
+        mock_auth.get_headers.return_value = {"Authorization": "Bearer fake_api_key"}
+        mock_auth.get_config.return_value = {
+            "api_base": "http://example.com",
+            "api_key": "fake_api_key",
+        }
+        OpenAIUser.auth_provider = mock_auth
+        OpenAIUser.host = "http://example.com"
+
+        user = OpenAIUser(environment=MagicMock())
+        user.on_start()
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello!"},
+        ]
+        user.sample = lambda: UserChatMessagesRequest(
+            model="gpt-4",
+            messages=messages,
+            num_prefill_tokens=10,
+            max_tokens=20,
+        )
+
+        # Mock response
+        response_mock = MagicMock()
+        response_mock.status_code = 200
+        response_mock.iter_lines = MagicMock(
+            return_value=[
+                b'data: {"id":"chat-1","object":"chat.completion.chunk","created":1,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}',
+                b'data: {"id":"chat-1","object":"chat.completion.chunk","created":1,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}',
+                b"data: [DONE]",
+            ]
+        )
+        mock_post.return_value = response_mock
+
+        user.chat()
+
+        # Verify the messages were passed directly (not wrapped in a user message)
+        call_args = mock_post.call_args
+        payload = call_args.kwargs["json"]
+        assert payload["messages"] == messages
+        assert payload["model"] == "gpt-4"
+
+    @patch("genai_bench.user.openai_user.requests.post")
+    def test_chat_accepts_messages_request_type(self, mock_post):
+        """Test that chat() accepts UserChatMessagesRequest without error."""
+        from genai_bench.user.openai_user import OpenAIUser
+
+        mock_auth = MagicMock()
+        mock_auth.get_credentials.return_value = "fake_key"
+        mock_auth.get_headers.return_value = {"Authorization": "Bearer fake_key"}
+        mock_auth.get_config.return_value = {
+            "api_base": "http://example.com",
+            "api_key": "fake_key",
+        }
+        OpenAIUser.auth_provider = mock_auth
+        OpenAIUser.host = "http://example.com"
+
+        user = OpenAIUser(environment=MagicMock())
+        user.on_start()
+
+        user.sample = lambda: UserChatMessagesRequest(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Test"}],
+            num_prefill_tokens=5,
+            max_tokens=10,
+        )
+
+        response_mock = MagicMock()
+        response_mock.status_code = 200
+        response_mock.iter_lines = MagicMock(
+            return_value=[
+                b'data: {"id":"chat-1","choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}',
+                b"data: [DONE]",
+            ]
+        )
+        mock_post.return_value = response_mock
+
+        # Should not raise
+        user.chat()
+        mock_post.assert_called_once()
+
+
+# -- Async Runner Tests --
+
+
+class TestAsyncRunnerMessageLists:
+    """Test BaseAsyncRunner with message list requests."""
+
+    def test_prepare_request_dataset_scenario(self):
+        """Test that 'dataset' scenario string passes None to sampler."""
+        from genai_bench.async_runner.base import BaseAsyncRunner
+
+        mock_sampler = MagicMock()
+        mock_sampler.sample = MagicMock(
+            return_value=UserChatMessagesRequest(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "Hello"}],
+                num_prefill_tokens=10,
+                max_tokens=20,
+            )
+        )
+
+        class TestRunner(BaseAsyncRunner):
+            async def run(self, *, duration_s: int, scenario: str, **kwargs):
+                return 1.0
+
+        mock_auth = MagicMock()
+        mock_auth.get_headers = MagicMock(
+            return_value={
+                "Authorization": "Bearer test",
+                "Content-Type": "application/json",
+            }
+        )
+
+        runner = TestRunner(
+            sampler=mock_sampler,
+            api_backend="openai",
+            api_base="https://api.openai.com",
+            api_model_name="gpt-4",
+            auth_provider=mock_auth,
+            aggregated_metrics_collector=MagicMock(),
+            dashboard=None,
+        )
+
+        req = runner._prepare_request("dataset")
+
+        # Sampler should be called with None (dataset mode)
+        mock_sampler.sample.assert_called_once_with(None)
+        assert isinstance(req, UserChatMessagesRequest)
+
+    def test_prepare_request_validates_messages(self):
+        """Test that prepare_request validates messages field."""
+        from genai_bench.async_runner.base import BaseAsyncRunner
+
+        mock_sampler = MagicMock()
+        mock_sampler.sample = MagicMock(
+            return_value=UserChatMessagesRequest(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "Hello"}],
+                num_prefill_tokens=10,
+                max_tokens=20,
+            )
+        )
+
+        class TestRunner(BaseAsyncRunner):
+            async def run(self, *, duration_s: int, scenario: str, **kwargs):
+                return 1.0
+
+        mock_auth = MagicMock()
+        mock_auth.get_headers = MagicMock(
+            return_value={
+                "Authorization": "Bearer test",
+                "Content-Type": "application/json",
+            }
+        )
+
+        runner = TestRunner(
+            sampler=mock_sampler,
+            api_backend="openai",
+            api_base="https://api.openai.com",
+            api_model_name="gpt-4",
+            auth_provider=mock_auth,
+            aggregated_metrics_collector=MagicMock(),
+            dashboard=None,
+        )
+
+        # Valid request - should not raise
+        req = runner._prepare_request("dataset")
+        assert isinstance(req, UserChatMessagesRequest)
+
+    def test_prepare_request_rejects_empty_messages(self):
+        """Test that prepare_request rejects requests with empty messages."""
+        from genai_bench.async_runner.base import BaseAsyncRunner
+
+        mock_sampler = MagicMock()
+        mock_sampler.sample = MagicMock(
+            return_value=UserChatMessagesRequest(
+                model="gpt-4",
+                messages=[],
+                num_prefill_tokens=10,
+                max_tokens=20,
+            )
+        )
+
+        class TestRunner(BaseAsyncRunner):
+            async def run(self, *, duration_s: int, scenario: str, **kwargs):
+                return 1.0
+
+        mock_auth = MagicMock()
+        mock_auth.get_headers = MagicMock(
+            return_value={
+                "Authorization": "Bearer test",
+                "Content-Type": "application/json",
+            }
+        )
+
+        runner = TestRunner(
+            sampler=mock_sampler,
+            api_backend="openai",
+            api_base="https://api.openai.com",
+            api_model_name="gpt-4",
+            auth_provider=mock_auth,
+            aggregated_metrics_collector=MagicMock(),
+            dashboard=None,
+        )
+
+        with pytest.raises(ValueError, match="missing required 'messages' field"):
+            runner._prepare_request("dataset")

--- a/tests/user/test_openai_user.py
+++ b/tests/user/test_openai_user.py
@@ -205,7 +205,7 @@ def test_chat_with_wrong_request_type(mock_openai_user):
 
     with pytest.raises(
         AttributeError,
-        match="user_request should be of type UserChatRequest for OpenAIUser.chat",
+        match="user_request should be of type UserChatRequest or UserChatMessagesRequest for OpenAIUser.chat",
     ):
         mock_openai_user.chat()
 


### PR DESCRIPTION
## Summary

- Adds support for benchmarking with pre-structured multi-turn conversations in OpenAI chat format
- New `--dataset-message-format openai` CLI option for message list datasets
- Full backward compatibility with existing string-based prompts

## Changes

### Feature
- **`UserChatMessagesRequest`** protocol model for structured messages (`protocol.py`)
- **`TextDatasetLoader`** extended with message list loading and validation (`data/loaders/text.py`)
- **`TextSampler`** extended with message-aware sampling and chat-template token counting (`sampling/text.py`)
- **`DatasetConfig`** gains `message_format` field with HuggingFace auto-detection (`data/config.py`)
- **`--dataset-message-format`** CLI option (`cli/option_groups.py`)
- Both **async runner** and **OpenAI user** handle `UserChatMessagesRequest` natively

### Bug fixes
- Restore `environment.sampler` assignment in Locust path (was removed, breaking Locust-based runs)
- Fix mismatched `scenario_metrics` dict key in Locust path (init vs append used different keys)

### Documentation
- User guide: new "Using message lists" section with JSON, CLI, and config examples
- CLI reference: document `--dataset-message-format` option
- Scenario guide: note message list behavior in dataset mode

### Tests
- 38 new unit tests in `tests/sampling/test_message_lists.py` covering:
  - `DatasetConfig` with `message_format`
  - `TextDatasetLoader` validation (12 edge cases)
  - `TextSampler` message list handling and token counting
  - `UserChatMessagesRequest` protocol
  - `OpenAIUser` with message lists
  - `BaseAsyncRunner` with dataset scenario

## Usage

```bash
genai-bench benchmark \
  --task text-to-text \
  --dataset-path my-org/multi-turn-dataset \
  --dataset-prompt-column messages \
  --dataset-message-format openai \
  --traffic-scenario dataset \
  --api-backend openai \
  --api-base http://localhost:8000 \
  --api-model-name my-model \
  --num-concurrency 1
```

## Test plan

- [x] `make test_changed` passes (62/62)
- [x] New test file passes (38/38)
- [x] Full test suite passes (925 passed; 87 pre-existing failures from cloud SDKs and async runner)
- [x] Validated end-to-end against live API with HuggingFace dataset `baseten/gamma_paste_text_benchmarking` (3/3 requests, 0 errors, 10k-18k input tokens per request)
- [x] Backward compatibility verified (string-based prompts unaffected)