### PR TITLE
Add protobuf dep and widen transformers upper bound to 5.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "locust>=2.37.14,<3.0.0",
     "numpy>=1.26.4",
     "requests>=2.32.3,<3.0.0",
-    "transformers>=4.44.2,<5.0.0",
+    "transformers>=4.44.2,<=5.5.4",
     "click>=8.1.7",
     "pandas>=2.2.2",
     "pydantic>=2.8.2",
@@ -39,6 +39,7 @@ dependencies = [
     "aiohttp>=3.9.0,<4.0.0",
     "orjson>=3.9.0",
     "torch>=2.9.1",
+    "protobuf>=4.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
protobuf is needed by transformers when loading SentencePiece tokenizers but was not declared as a direct dependency, causing failures when installing via `uv run --with`. Also widens the transformers upper bound from <5.0.0 to <=5.5.4 to allow use of transformers 5.x.

## Description
<!--Please provide a brief description of the changes in this PR.-->

## Related Issue
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->

## Changes
<!-- 
List the changes made in this PR.
-->

## Correctness Tests
<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## Checklist
- [x] I have rebased my branch on top of the latest main branch (`git pull origin main`)
- [x] I have run `make check` to ensure code is properly formatted and passes all lint checks
- [x] I have run `make test` or `make test_changed` to verify test coverage (~90% required)
- [x] I have added tests that fail without my code changes (for bug fixes)
- [x] I have added tests covering variants of new features (for new features)

## Additional Information
Add any other context, screenshots, or information about the PR here.
