### PR TITLE
Add MixedScenario for weighted multi-profile load tests

### DIFF
--- a/genai_bench/sampling/text.py
+++ b/genai_bench/sampling/text.py
@@ -51,6 +51,14 @@ class TextSampler(Sampler):
         # Key: scenario identifier, Value: generated prefix text
         self._shared_prefix_cache: Dict[str, str] = {}
         self._suffix_counter = 0
+        # Nested mega-prefix for cross-scenario prefix sharing (used in Mixed mode).
+        # Stores the decoded text AND its tokenized form so we can slice to any
+        # requested prefix_len deterministically.
+        self._mega_prefix_text: Optional[str] = None
+        self._mega_prefix_tokens: Optional[List[int]] = None
+        # When set, reset_prefix_cache becomes a no-op and _shared_prefix_cache
+        # is derived from _mega_prefix_tokens (slice-based per prefix_len).
+        self._mega_prefix_pinned: bool = False
 
     def sample(self, scenario: Optional[Scenario]) -> UserRequest:
         """
@@ -81,8 +89,18 @@ class TextSampler(Sampler):
             if "ignore_eos" not in self.additional_request_params:
                 self.additional_request_params["ignore_eos"] = False
         else:
-            # Check if this is a prefix repetition scenario
-            from genai_bench.scenarios.text import PrefixRepetitionScenario
+            # Check if this is a prefix repetition or mixed scenario
+            from genai_bench.scenarios.text import (
+                MixedScenario,
+                PrefixRepetitionScenario,
+            )
+
+            if isinstance(scenario, MixedScenario):
+                # Pre-build a mega-prefix sized to the largest sub-prefix so
+                # all classes share a common leading slice. Pin it so the CLI's
+                # inter-scenario reset_prefix_cache() call doesn't clobber it.
+                self._ensure_mega_prefix_for_mixed(scenario)
+                scenario = scenario.sample()
 
             if isinstance(scenario, PrefixRepetitionScenario):
                 return self._sample_prefix_repetition_request(scenario)
@@ -290,9 +308,15 @@ class TextSampler(Sampler):
         """
         prefix_len, suffix_len, output_len = scenario.sample()
 
-        # Get or create shared prefix (cached for ALL requests in this scenario run)
+        # Get or create shared prefix (cached for ALL requests in this scenario run).
+        # When a mega-prefix is pinned (mixed mode), derive each sub-scenario's
+        # prefix as a leading slice of the mega-prefix so all sub-scenarios share
+        # a common head (nested shared prefix).
         cache_key = f"prefix_{prefix_len}"
-        if cache_key not in self._shared_prefix_cache:
+        if self._mega_prefix_pinned:
+            prefix = self._cached_slice_from_mega(prefix_len)
+            self._shared_prefix_cache[cache_key] = prefix
+        elif cache_key not in self._shared_prefix_cache:
             # Generate the shared prefix once
             prefix = self._sample_text(prefix_len)
             self._shared_prefix_cache[cache_key] = prefix
@@ -371,30 +395,31 @@ class TextSampler(Sampler):
         expected_tokens = prefix_len + suffix_len
         self._check_discrepancy(expected_tokens, num_prefill_tokens, threshold=0.05)
 
-        # Set ignore_eos to ensure we get the expected output length
-        self.additional_request_params["ignore_eos"] = True
-
-        # Set min_tokens and max_tokens from scenario's desired output
-        # This ensures the model generates the expected number of tokens
-        # Scenario values take precedence over user-provided values to ensure benchmark consistency
+        # Build per-request params (copy to avoid cross-request mutation when
+        # concurrent requests have different output_len, e.g. in Mixed mode).
+        params = dict(self.additional_request_params)
+        params["ignore_eos"] = True
         if not self.no_min_tokens:
-            self.additional_request_params["min_tokens"] = output_len
-        self.additional_request_params["max_tokens"] = output_len
+            params["min_tokens"] = output_len
+        params["max_tokens"] = output_len
 
         return UserChatRequest(
             model=self.model,
             prompt=prompt,
             num_prefill_tokens=num_prefill_tokens,
             max_tokens=output_len,
-            additional_request_params=self.additional_request_params,
+            additional_request_params=params,
         )
 
     def reset_prefix_cache(self):
         """Clear the prefix cache and reset counter.
 
         This should be called between different scenario runs to ensure
-        each scenario gets a fresh prefix.
+        each scenario gets a fresh prefix. No-op when a mega-prefix is pinned
+        (mixed mode), since all sub-scenarios are meant to share the same head.
         """
+        if self._mega_prefix_pinned:
+            return
         if self._suffix_counter > 0:
             logger.info(
                 f"🔄 Resetting prefix cache. Previous scenario generated {self._suffix_counter} requests "
@@ -402,3 +427,71 @@ class TextSampler(Sampler):
             )
         self._shared_prefix_cache.clear()
         self._suffix_counter = 0
+
+    def _ensure_mega_prefix_for_mixed(self, mixed_scenario) -> None:
+        """Pre-generate a mega-prefix for a MixedScenario so sub-scenarios with
+        different prefix_len share a common head (nested shared prefix)."""
+        from genai_bench.scenarios.text import PrefixRepetitionScenario
+
+        prefix_lens = [
+            sub.prefix_len
+            for sub in mixed_scenario.sub_scenarios
+            if isinstance(sub, PrefixRepetitionScenario)
+        ]
+        if not prefix_lens:
+            return
+
+        max_prefix_len = max(prefix_lens)
+        current_len = (
+            len(self._mega_prefix_tokens) if self._mega_prefix_tokens else 0
+        )
+        if current_len >= max_prefix_len:
+            self._mega_prefix_pinned = True
+            return
+
+        text = self._sample_text(max_prefix_len)
+        tokens = self.tokenizer.encode(text, add_special_tokens=False)
+        self._mega_prefix_tokens = tokens
+        self._mega_prefix_text = text
+        self._mega_prefix_pinned = True
+        self._shared_prefix_cache.clear()
+
+        import hashlib
+
+        prefix_hash = hashlib.md5(text.encode()).hexdigest()[:8]
+        logger.info(
+            f"🧬 Generated nested mega-prefix ({len(tokens)} tokens, hash "
+            f"{prefix_hash}) for mixed scenario. Sub-scenarios with "
+            f"prefix_len={prefix_lens} will each slice from this prefix."
+        )
+
+    def _cached_slice_from_mega(self, prefix_len: int) -> str:
+        """Return a stable leading slice of the mega-prefix.
+
+        The slice is cached per prefix_len so identical calls return the exact
+        same text (enabling KV cache hits). BPE tokenizers may round-trip
+        tokens->text->tokens with small boundary drift; the final prefill
+        count is measured post-tokenization and absorbed by the 5% tolerance
+        in _check_discrepancy.
+        """
+        cache_key = f"prefix_{prefix_len}"
+        cached = self._shared_prefix_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        if self._mega_prefix_tokens is None:
+            raise RuntimeError(
+                "Mega-prefix not initialized; call _ensure_mega_prefix_for_mixed first"
+            )
+
+        available = len(self._mega_prefix_tokens)
+        if prefix_len > available:
+            raise ValueError(
+                f"Requested prefix_len {prefix_len} exceeds mega-prefix length {available}"
+            )
+
+        sliced = self.tokenizer.decode(
+            self._mega_prefix_tokens[:prefix_len], skip_special_tokens=True
+        )
+        self._shared_prefix_cache[cache_key] = sliced
+        return sliced

--- a/genai_bench/scenarios/base.py
+++ b/genai_bench/scenarios/base.py
@@ -13,6 +13,7 @@ class TextDistribution(Enum):
     DETERMINISTIC = "D"
     UNIFORM = "U"
     PREFIX_REPETITION = "P"
+    MIXED = "M"
 
 
 class EmbeddingDistribution(Enum):

--- a/genai_bench/scenarios/text.py
+++ b/genai_bench/scenarios/text.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple
+import re
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -275,8 +276,6 @@ class PrefixRepetitionScenario(Scenario):
         """
         # Parse P(prefix_len,suffix_len)/output_len
         # params_str will be "(2000,500)/200"
-        import re
-
         match = re.match(r"\((\d+),(\d+)\)/(\d+)", params_str)
         if not match:
             raise ValueError(
@@ -287,3 +286,115 @@ class PrefixRepetitionScenario(Scenario):
         suffix_len = int(match.group(2))
         output_len = int(match.group(3))
         return cls(prefix_len, suffix_len, output_len)
+
+
+def _split_top_level_commas(body: str) -> List[str]:
+    """Split body on commas that are at paren depth 0."""
+    parts = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(body):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                raise ValueError(f"Unbalanced parentheses in: {body}")
+        elif ch == "," and depth == 0:
+            parts.append(body[start:i].strip())
+            start = i + 1
+    if depth != 0:
+        raise ValueError(f"Unbalanced parentheses in: {body}")
+    parts.append(body[start:].strip())
+    return [p for p in parts if p]
+
+
+class MixedScenario(Scenario):
+    """
+    A weighted mixture of sub-scenarios that dispatches per request.
+
+    Format: M(w1:SUBSCEN,w2:SUBSCEN,...)
+    Example: M(0.4:P(7840,160)/200,0.4:P(31360,640)/500,0.2:P(78400,1600)/1000)
+
+    Each sub-scenario is any other scenario string (P/D/N/U). Weights are
+    normalized to sum to 1. On each sample() call, a sub-scenario is drawn by
+    weighted random choice; the returned Scenario is dispatched by the sampler
+    to its normal generation path.
+    """
+
+    scenario_type = TextDistribution.MIXED
+    validation_pattern = r"^M\(.+\)$"
+
+    def __init__(
+        self, weights: List[float], sub_scenarios: List[Scenario]
+    ):
+        if len(weights) != len(sub_scenarios) or not sub_scenarios:
+            raise ValueError(
+                "MixedScenario requires matching non-empty weights and "
+                "sub_scenarios"
+            )
+        total = float(sum(weights))
+        if total <= 0:
+            raise ValueError("MixedScenario weights must sum to a positive number")
+        self.weights = [w / total for w in weights]
+        self.sub_scenarios = sub_scenarios
+        self._rng = np.random.default_rng()
+
+    def sample(self) -> Scenario:
+        """Return one of the sub-scenarios by weighted random choice.
+
+        The return type is a Scenario (not a tuple), since MixedScenario is a
+        dispatcher: the sampler inspects the returned Scenario and delegates
+        to the appropriate generation path (e.g. prefix-repetition).
+        """
+        idx = int(self._rng.choice(len(self.sub_scenarios), p=self.weights))
+        return self.sub_scenarios[idx]
+
+    def to_string(self) -> str:
+        parts = [
+            f"{w}:{s.to_string()}" for w, s in zip(self.weights, self.sub_scenarios)
+        ]
+        return f"M({','.join(parts)})"
+
+    @classmethod
+    def parse(cls, params_str: str) -> "MixedScenario":
+        """
+        Parse a Mixed scenario string.
+
+        Example: "(0.4:P(7840,160)/200,0.4:P(31360,640)/500,0.2:P(78400,1600)/1000)"
+        """
+        if not (params_str.startswith("(") and params_str.endswith(")")):
+            raise ValueError(
+                f"Invalid mixed format: {params_str}. Expected M(w:SUB,w:SUB,...)"
+            )
+        body = params_str[1:-1]
+        entries = _split_top_level_commas(body)
+        if not entries:
+            raise ValueError(f"MixedScenario requires at least one sub-scenario: {params_str}")
+
+        weights: List[float] = []
+        subs: List[Scenario] = []
+        for entry in entries:
+            if ":" not in entry:
+                raise ValueError(
+                    f"Mixed sub-scenario '{entry}' must be WEIGHT:SUBSCEN"
+                )
+            weight_str, sub_str = entry.split(":", 1)
+            weight_str = weight_str.strip()
+            sub_str = sub_str.strip()
+            try:
+                weight = float(weight_str)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid weight '{weight_str}' in mixed scenario"
+                ) from e
+            if weight <= 0:
+                raise ValueError(
+                    f"Mixed weight must be positive, got {weight} for '{entry}'"
+                )
+            sub = Scenario.from_string(sub_str)
+            if isinstance(sub, MixedScenario):
+                raise ValueError("MixedScenario cannot be nested")
+            weights.append(weight)
+            subs.append(sub)
+        return cls(weights, subs)

--- a/tests/sampling/test_mixed.py
+++ b/tests/sampling/test_mixed.py
@@ -1,0 +1,129 @@
+"""Tests for mixed scenario dispatch and nested mega-prefix sharing in the sampler."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from genai_bench.sampling.text import TextSampler
+from genai_bench.scenarios.text import (
+    MixedScenario,
+    PrefixRepetitionScenario,
+)
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer: each whitespace-separated token -> one id.
+
+    Decode just joins ids back with spaces. Deterministic so tests can verify
+    slice-based prefix sharing without numeric drift.
+    """
+
+    def __init__(self):
+        self._next_id = 100_000
+        self._token_to_id: dict[str, int] = {}
+        self._id_to_token: dict[int, str] = {}
+
+    def _id_for(self, token: str) -> int:
+        if token not in self._token_to_id:
+            self._token_to_id[token] = self._next_id
+            self._id_to_token[self._next_id] = token
+            self._next_id += 1
+        return self._token_to_id[token]
+
+    def encode(self, text, add_special_tokens=False):  # noqa: D401
+        return [self._id_for(t) for t in text.split(" ") if t]
+
+    def decode(self, ids, skip_special_tokens=True):  # noqa: D401
+        return " ".join(self._id_to_token[i] for i in ids)
+
+
+class TestMixedSamplerNestedPrefix(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer = _FakeTokenizer()
+        # Each "line" is a wide unique-token chunk so _sample_text produces
+        # a long deterministic stream.
+        self.data = [" ".join(f"w{i:05d}" for i in range(k * 200, (k + 1) * 200)) for k in range(100)]
+        self.sampler = TextSampler(
+            tokenizer=self.tokenizer,
+            model="mock_model",
+            output_modality="text",
+            data=self.data,
+        )
+
+    def test_ensure_mega_prefix_generates_once_sized_to_max(self):
+        scen = MixedScenario(
+            weights=[0.5, 0.5],
+            sub_scenarios=[
+                PrefixRepetitionScenario(50, 10, 5),
+                PrefixRepetitionScenario(200, 10, 5),
+            ],
+        )
+        self.sampler._ensure_mega_prefix_for_mixed(scen)
+        assert self.sampler._mega_prefix_tokens is not None
+        assert len(self.sampler._mega_prefix_tokens) >= 200
+        assert self.sampler._mega_prefix_pinned is True
+
+    def test_mega_prefix_slices_produce_nested_prefixes(self):
+        short = PrefixRepetitionScenario(50, 10, 5)
+        medium = PrefixRepetitionScenario(120, 10, 5)
+        long_ = PrefixRepetitionScenario(300, 10, 5)
+        scen = MixedScenario(
+            weights=[0.4, 0.4, 0.2],
+            sub_scenarios=[short, medium, long_],
+        )
+
+        # Trigger a dispatch via sample() which internally ensures mega-prefix.
+        self.sampler._ensure_mega_prefix_for_mixed(scen)
+
+        short_req = self.sampler._sample_prefix_repetition_request(short)
+        medium_req = self.sampler._sample_prefix_repetition_request(medium)
+        long_req = self.sampler._sample_prefix_repetition_request(long_)
+
+        short_prefix = short_req.prompt.split("\n\n--- Request #")[0]
+        medium_prefix = medium_req.prompt.split("\n\n--- Request #")[0]
+        long_prefix = long_req.prompt.split("\n\n--- Request #")[0]
+
+        # Nested: shorter prefix is a prefix of longer prefix.
+        assert medium_prefix.startswith(short_prefix)
+        assert long_prefix.startswith(medium_prefix)
+        assert long_prefix.startswith(short_prefix)
+
+    def test_reset_prefix_cache_noop_when_pinned(self):
+        scen = MixedScenario(
+            weights=[1.0],
+            sub_scenarios=[PrefixRepetitionScenario(50, 10, 5)],
+        )
+        self.sampler._ensure_mega_prefix_for_mixed(scen)
+        before_tokens = self.sampler._mega_prefix_tokens
+        self.sampler.reset_prefix_cache()
+        # Pinned state preserved; mega-prefix untouched
+        assert self.sampler._mega_prefix_pinned is True
+        assert self.sampler._mega_prefix_tokens is before_tokens
+
+    def test_sample_dispatches_mixed_via_sample_method(self):
+        short = PrefixRepetitionScenario(50, 10, 5)
+        scen = MixedScenario(weights=[1.0], sub_scenarios=[short])
+        req = self.sampler.sample(scen)
+        # Request generated through mixed path should have a prompt with the
+        # '--- Request #' marker emitted by prefix-repetition sampling.
+        assert "Request #" in req.prompt
+
+    def test_additional_request_params_are_per_request(self):
+        """Regression: each request gets its own params dict so concurrent
+        requests with different output_len don't clobber each other."""
+        short = PrefixRepetitionScenario(50, 10, 7)
+        long_ = PrefixRepetitionScenario(300, 10, 42)
+        scen = MixedScenario(weights=[0.5, 0.5], sub_scenarios=[short, long_])
+        self.sampler._ensure_mega_prefix_for_mixed(scen)
+
+        short_req = self.sampler._sample_prefix_repetition_request(short)
+        long_req = self.sampler._sample_prefix_repetition_request(long_)
+        assert short_req.additional_request_params["max_tokens"] == 7
+        assert long_req.additional_request_params["max_tokens"] == 42
+        # After generating long_req, short_req's params dict must not be
+        # mutated.
+        assert short_req.additional_request_params["max_tokens"] == 7
+        assert short_req.additional_request_params is not long_req.additional_request_params
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scenarios/test_mixed.py
+++ b/tests/scenarios/test_mixed.py
@@ -1,0 +1,80 @@
+"""Tests for MixedScenario parsing, weighted sampling, and validation."""
+
+from collections import Counter
+
+import pytest
+
+from genai_bench.scenarios.base import Scenario
+from genai_bench.scenarios.text import (
+    DeterministicDistribution,
+    MixedScenario,
+    PrefixRepetitionScenario,
+)
+
+
+def test_mixed_scenario_parse_three_prefix_subs():
+    s = Scenario.from_string(
+        "M(0.4:P(7840,160)/200,0.4:P(31360,640)/500,0.2:P(78400,1600)/1000)"
+    )
+    assert isinstance(s, MixedScenario)
+    assert len(s.sub_scenarios) == 3
+    assert all(isinstance(x, PrefixRepetitionScenario) for x in s.sub_scenarios)
+    assert s.weights == pytest.approx([0.4, 0.4, 0.2])
+
+
+def test_mixed_scenario_weights_normalize():
+    s = Scenario.from_string("M(2:D(10,5),3:D(20,10))")
+    assert s.weights == pytest.approx([0.4, 0.6])
+
+
+def test_mixed_scenario_mixed_sub_types():
+    s = Scenario.from_string("M(0.5:P(100,50)/25,0.5:D(200,100))")
+    assert isinstance(s.sub_scenarios[0], PrefixRepetitionScenario)
+    assert isinstance(s.sub_scenarios[1], DeterministicDistribution)
+
+
+def test_mixed_scenario_to_string_round_trip():
+    original = "M(0.4:P(7840,160)/200,0.4:P(31360,640)/500,0.2:P(78400,1600)/1000)"
+    s = Scenario.from_string(original)
+    reparsed = Scenario.from_string(s.to_string())
+    assert isinstance(reparsed, MixedScenario)
+    assert reparsed.weights == pytest.approx(s.weights)
+
+
+def test_mixed_scenario_sample_distribution_matches_weights():
+    s = MixedScenario(
+        weights=[0.4, 0.4, 0.2],
+        sub_scenarios=[
+            PrefixRepetitionScenario(7840, 160, 200),
+            PrefixRepetitionScenario(31360, 640, 500),
+            PrefixRepetitionScenario(78400, 1600, 1000),
+        ],
+    )
+    draws = [id(s.sample()) for _ in range(20000)]
+    counts = Counter(draws)
+    total = sum(counts.values())
+    fractions = sorted(c / total for c in counts.values())
+    # With 20k draws, each fraction should be within ~1.5 percentage points
+    assert fractions[0] == pytest.approx(0.2, abs=0.02)
+    assert fractions[1] == pytest.approx(0.4, abs=0.02)
+    assert fractions[2] == pytest.approx(0.4, abs=0.02)
+
+
+def test_mixed_scenario_rejects_nested():
+    with pytest.raises(ValueError, match="cannot be nested"):
+        Scenario.from_string("M(0.5:M(1:D(10,5)),0.5:D(20,10))")
+
+
+def test_mixed_scenario_rejects_missing_weight():
+    with pytest.raises(ValueError, match="WEIGHT:SUBSCEN"):
+        Scenario.from_string("M(D(10,5),D(20,10))")
+
+
+def test_mixed_scenario_rejects_negative_weight():
+    with pytest.raises(ValueError, match="positive"):
+        Scenario.from_string("M(-0.5:D(10,5),1:D(20,10))")
+
+
+def test_mixed_scenario_rejects_empty():
+    with pytest.raises(ValueError):
+        Scenario.from_string("M()")


### PR DESCRIPTION
## Summary

Adds a new `M(...)` scenario type that runs a weighted mix of sub-scenarios in a single benchmark run. I added this because Poolside had a traffic profile that they wanted to benchmark: 

<img width="717" height="80" alt="image" src="https://github.com/user-attachments/assets/b507b6fa-acf7-426a-a9a9-e00a41f8580d" />

This adds support for that.

**Example:**
```
--traffic-scenario "M(0.4:P(7840,160)/200,0.4:P(31360,640)/500,0.2:P(78400,1600)/1000)"
```

Each sub-scenario is any existing scenario string (`P`/`D`/`N`/`U`). Weights are normalized and one sub-scenario is drawn per arrival. When sub-scenarios are `PrefixRepetitionScenario`, the sampler pre-generates a single **nested mega-prefix** sized to the largest sub-prefix, so all classes share a common leading slice and KV-cache hits transfer across classes — matching real workloads with a shared system prompt.

Here it is in action. This is pulled from this deployment [[link](https://app.baseten.co/models/qvv282eq/metrics/qrjorp5)] and shows the differently sized inputs:
<img width="834" height="345" alt="image" src="https://github.com/user-attachments/assets/4f798a87-8a8c-4585-9938-2950e19408a9" />



## Details

- `genai_bench/scenarios/base.py`: adds `TextDistribution.MIXED = "M"`.
- `genai_bench/scenarios/text.py`: adds `MixedScenario` with a top-level-comma-aware parser (respects nested parens in sub-scenarios), normalized weights, and a `sample()` that returns a sub-`Scenario` for the sampler to dispatch. Nested `M(...M(...)...)` is explicitly rejected.
- `genai_bench/sampling/text.py`:
  - Dispatches `MixedScenario` at the top of `_sample_chat_request` by ensuring the mega-prefix and then delegating to the sub-scenario's normal path.
  - Adds `_ensure_mega_prefix_for_mixed` (pre-generates one prefix sized to `max(prefix_len)`) and `_cached_slice_from_mega` (stable leading slices per `prefix_len`).
  - Makes `reset_prefix_cache` a no-op once the mega-prefix is pinned, so the CLI's inter-scenario resets in `cli.py:554` and `cli.py:866` don't drop the shared state.
  - **Latent race fix (applies broadly):** `_sample_prefix_repetition_request` previously mutated `self.additional_request_params` (a shared dict) and passed a reference to `UserChatRequest`. With concurrent in-flight requests that have different `output_len` — exactly what Mixed mode introduces — request A could overwrite request B's `max_tokens` before serialization. The path now copies params per-request.

## Test plan

- [x] `tests/scenarios/test_mixed.py` — 9 tests: parse, round-trip, weight normalization, weighted-sample distribution (20k draws), mixed sub-scenario types, nested-rejection, missing-weight, negative-weight, empty.
- [x] `tests/sampling/test_mixed.py` — 5 tests: mega-prefix sizing, nested-prefix slicing (Short ⊂ Medium ⊂ Long), `reset_prefix_cache` no-op when pinned, `sample()` dispatch through the Mixed path, per-request `additional_request_params` isolation.
- [x] Full existing suite still passes (scenario + sampling tests).
- [x] Validated end-to-end against a real Baseten Laguna deployment: 17,000+ requests across sanity + 2 RPS sweeps (0 errors), nested prefix caching confirmed via worker-side `worker_kv_cache_hit_rate` metrics at 96-97%.

## Backwards compatibility

No behavior change for non-Mixed scenarios. The `additional_request_params` fix is a bug fix for the `PrefixRepetitionScenario` path — existing single-scenario runs serialize identically.