### PR TITLE
Add optional num_images param to ID() and IP() scenarios

### DIFF
--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -521,14 +521,16 @@ def experiment_options(func):
                 \b
                 2. **Deterministic Image (ID)**: Unique synthetic text + image per request.
                    No prefix caching — conservative throughput lower bound.
-                   - Format: ID(width,height,input_tokens,output_tokens)
-                   - Example: ID(1024,1024,1500,200)
+                   - Format: ID(width,height,input_tokens,output_tokens[,num_images])
+                   - Example: ID(1024,1024,1500,200)       — 1 image (default)
+                              ID(1024,1024,1500,200,3)     — 3 images per request
 
                 \b
                 3. **Prefix Image (IP)**: Shared text prefix + unique suffix + image.
                    Benchmarks KV cache hit rates for prefix-heavy workloads.
-                   - Format: IP(width,height,prefix_tokens,suffix_tokens)/output_tokens
-                   - Example: IP(1024,1024,1200,300)/200
+                   - Format: IP(width,height,prefix_tokens,suffix_tokens[,num_images])/output_tokens
+                   - Example: IP(1024,1024,1200,300)/200     — 1 image (default)
+                              IP(1024,1024,1200,300,3)/200   — 3 images per request
 
                 \b
                 Supported embeddings are:

--- a/genai_bench/scenarios/multimodal.py
+++ b/genai_bench/scenarios/multimodal.py
@@ -76,12 +76,16 @@ class DeterministicImageScenario(Scenario):
     All text tokens are unique per request (no prefix caching).
     Images are sampled from the dataset without replacement.
 
-    Format: ID(width, height, input_tokens, output_tokens)
-    Example: ID(1024,1024,1500,200)
+    Format: ID(width, height, input_tokens, output_tokens[, num_images])
+      - 4-param form: ID(w, h, input_tokens, output_tokens) — defaults to 1 image
+      - 5-param form: ID(w, h, input_tokens, output_tokens, N) — N images per request
+    Example: ID(1024,1024,1500,200)     — single image (default)
+             ID(1024,1024,1500,200,3)   — three images per request
     """
 
     scenario_type = MultiModality.DETERMINISTIC_IMAGE
-    validation_pattern = r"^ID\(\d+,\d+,\d+,\d+\)$"
+    # 4 or 5 positional ints inside ID(...)
+    validation_pattern = r"^ID\(\d+,\d+,\d+,\d+(?:,\d+)?\)$"
 
     def __init__(
         self,
@@ -89,36 +93,55 @@ class DeterministicImageScenario(Scenario):
         num_input_dimension_height: int,
         num_input_tokens: int,
         num_output_tokens: int,
+        num_images: int = 1,
     ):
         self.num_input_dimension_width = num_input_dimension_width
         self.num_input_dimension_height = num_input_dimension_height
         self.num_input_tokens = num_input_tokens
         self.num_output_tokens = num_output_tokens
+        self.num_images = num_images
 
     def sample(self) -> Tuple[Tuple[int, int], int, int, int]:
         return (
             (self.num_input_dimension_width, self.num_input_dimension_height),
-            1,  # num_images — TODO: extend format to ID(w,h,N,input,output) for multi-image support
+            self.num_images,
             self.num_input_tokens,
             self.num_output_tokens,
         )
 
     def to_string(self) -> str:
-        return (
+        base = (
             f"ID({self.num_input_dimension_width},"
             f"{self.num_input_dimension_height},"
             f"{self.num_input_tokens},"
-            f"{self.num_output_tokens})"
+            f"{self.num_output_tokens}"
         )
+        # Only emit num_images when > 1, so the canonical form for the common
+        # single-image case matches the legacy 4-param shape exactly.
+        if self.num_images != 1:
+            return f"{base},{self.num_images})"
+        return f"{base})"
 
     @classmethod
     def parse(cls, params_str: str) -> "DeterministicImageScenario":
-        w, h, input_tokens, output_tokens = parse_params_str(params_str)[0]
+        params = parse_params_str(params_str)[0]
+        if len(params) == 4:
+            w, h, input_tokens, output_tokens = params
+            num_images = 1
+        elif len(params) == 5:
+            w, h, input_tokens, output_tokens, num_images = params
+        else:
+            raise ValueError(
+                f"Invalid ID() format: {params_str}. "
+                f"Expected 4 or 5 params: (w,h,input_tokens,output_tokens) "
+                f"or (w,h,input_tokens,output_tokens,num_images)"
+            )
         return cls(
             num_input_dimension_width=w,
             num_input_dimension_height=h,
             num_input_tokens=input_tokens,
             num_output_tokens=output_tokens,
+            num_images=num_images,
         )
 
 
@@ -129,12 +152,16 @@ class PrefixImageScenario(Scenario):
     All requests share a cached text prefix with unique suffixes.
     Images are sampled from the dataset without replacement.
 
-    Format: IP(width, height, prefix_tokens, suffix_tokens)/output_tokens
-    Example: IP(1024,1024,1200,300)/200
+    Format: IP(width, height, prefix_tokens, suffix_tokens[, num_images])/output_tokens
+      - 4-param form: IP(w, h, prefix_tokens, suffix_tokens)/output — defaults to 1 image
+      - 5-param form: IP(w, h, prefix_tokens, suffix_tokens, N)/output — N images per request
+    Example: IP(1024,1024,1200,300)/200     — single image (default)
+             IP(1024,1024,1200,300,3)/200   — three images per request
     """
 
     scenario_type = MultiModality.PREFIX_IMAGE
-    validation_pattern = r"^IP\(\d+,\d+,\d+,\d+\)/\d+$"
+    # 4 or 5 positional ints inside IP(...)/output
+    validation_pattern = r"^IP\(\d+,\d+,\d+,\d+(?:,\d+)?\)/\d+$"
 
     def __init__(
         self,
@@ -143,48 +170,60 @@ class PrefixImageScenario(Scenario):
         prefix_tokens: int,
         suffix_tokens: int,
         output_tokens: int,
+        num_images: int = 1,
     ):
         self.num_input_dimension_width = num_input_dimension_width
         self.num_input_dimension_height = num_input_dimension_height
         self.prefix_tokens = prefix_tokens
         self.suffix_tokens = suffix_tokens
         self.output_tokens = output_tokens
+        self.num_images = num_images
 
     def sample(self) -> Tuple[Tuple[int, int], int, int, int, int]:
         return (
             (self.num_input_dimension_width, self.num_input_dimension_height),
-            1,  # num_images — TODO: extend format to IP(w,h,N,prefix,suffix)/output for multi-image support
+            self.num_images,
             self.prefix_tokens,
             self.suffix_tokens,
             self.output_tokens,
         )
 
     def to_string(self) -> str:
-        return (
+        base = (
             f"IP({self.num_input_dimension_width},"
             f"{self.num_input_dimension_height},"
             f"{self.prefix_tokens},"
-            f"{self.suffix_tokens})/"
-            f"{self.output_tokens}"
+            f"{self.suffix_tokens}"
         )
+        if self.num_images != 1:
+            base = f"{base},{self.num_images}"
+        return f"{base})/{self.output_tokens}"
 
     @classmethod
     def parse(cls, params_str: str) -> "PrefixImageScenario":
-        match = re.match(r"\((\d+),(\d+),(\d+),(\d+)\)/(\d+)", params_str)
-        if not match:
+        # Try 5-param form first, then fall back to 4-param form.
+        match_5 = re.match(r"\((\d+),(\d+),(\d+),(\d+),(\d+)\)/(\d+)", params_str)
+        match_4 = re.match(r"\((\d+),(\d+),(\d+),(\d+)\)/(\d+)", params_str)
+        if match_5:
+            w, h, prefix_tokens, suffix_tokens, num_images, output_tokens = (
+                int(x) for x in match_5.groups()
+            )
+        elif match_4:
+            w, h, prefix_tokens, suffix_tokens, output_tokens = (
+                int(x) for x in match_4.groups()
+            )
+            num_images = 1
+        else:
             raise ValueError(
                 f"Invalid prefix image format: {params_str}. "
-                f"Expected format: (w,h,prefix_tokens,suffix_tokens)/output_tokens"
+                f"Expected (w,h,prefix_tokens,suffix_tokens)/output_tokens "
+                f"or (w,h,prefix_tokens,suffix_tokens,num_images)/output_tokens"
             )
-        w = int(match.group(1))
-        h = int(match.group(2))
-        prefix_tokens = int(match.group(3))
-        suffix_tokens = int(match.group(4))
-        output_tokens = int(match.group(5))
         return cls(
             num_input_dimension_width=w,
             num_input_dimension_height=h,
             prefix_tokens=prefix_tokens,
             suffix_tokens=suffix_tokens,
             output_tokens=output_tokens,
+            num_images=num_images,
         )

--- a/tests/scenarios/test_multimodal.py
+++ b/tests/scenarios/test_multimodal.py
@@ -162,7 +162,86 @@ def test_deterministic_image_invalid_formats():
     with pytest.raises(ValueError):
         Scenario.from_string("ID(512)")  # too few params
     with pytest.raises(ValueError):
-        Scenario.from_string("ID(512,512,100,200,300)")  # too many params
+        Scenario.from_string("ID(512,512,100,200,3,4)")  # too many params (6)
+
+
+# --- DeterministicImageScenario multi-image (5-param form) tests ---
+
+
+def test_deterministic_image_multi_image_creation():
+    """Test DeterministicImageScenario creation with explicit num_images."""
+    scenario = DeterministicImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        num_input_tokens=1500,
+        num_output_tokens=200,
+        num_images=3,
+    )
+    assert scenario.num_images == 3
+
+
+def test_deterministic_image_single_image_default():
+    """4-param form (no num_images) defaults to 1 image — backward compat."""
+    scenario = DeterministicImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        num_input_tokens=1500,
+        num_output_tokens=200,
+    )
+    assert scenario.num_images == 1
+
+
+def test_deterministic_image_multi_image_sampling():
+    """sample() returns the configured num_images, not hardcoded 1."""
+    scenario = DeterministicImageScenario(
+        num_input_dimension_width=512,
+        num_input_dimension_height=512,
+        num_input_tokens=800,
+        num_output_tokens=100,
+        num_images=4,
+    )
+    _, num_images, _, _ = scenario.sample()
+    assert num_images == 4
+
+
+def test_deterministic_image_multi_image_to_string():
+    """5-param form roundtrips with trailing num_images."""
+    scenario = DeterministicImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        num_input_tokens=1500,
+        num_output_tokens=200,
+        num_images=3,
+    )
+    assert scenario.to_string() == "ID(1024,1024,1500,200,3)"
+
+
+def test_deterministic_image_single_image_to_string_is_4param():
+    """Single-image form omits num_images from the string (legacy shape)."""
+    scenario = DeterministicImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        num_input_tokens=1500,
+        num_output_tokens=200,
+        num_images=1,
+    )
+    assert scenario.to_string() == "ID(1024,1024,1500,200)"
+
+
+def test_deterministic_image_parse_multi_image():
+    """5-param form parses num_images from the trailing position."""
+    scenario = DeterministicImageScenario.parse("(1024,1024,1500,200,3)")
+    assert scenario.num_input_dimension_width == 1024
+    assert scenario.num_input_tokens == 1500
+    assert scenario.num_output_tokens == 200
+    assert scenario.num_images == 3
+
+
+def test_deterministic_image_from_string_multi_image():
+    """Scenario.from_string routes the 5-param form correctly."""
+    scenario = Scenario.from_string("ID(1024,1024,1500,200,3)")
+    assert isinstance(scenario, DeterministicImageScenario)
+    assert scenario.num_images == 3
 
 
 # --- PrefixImageScenario (IP) tests ---
@@ -236,3 +315,88 @@ def test_prefix_image_invalid_formats():
         Scenario.from_string("IP(512,512,100,200)")  # missing /output
     with pytest.raises(ValueError):
         Scenario.from_string("IP(512,512)")  # too few params
+
+
+# --- PrefixImageScenario multi-image (5-param form) tests ---
+
+
+def test_prefix_image_multi_image_creation():
+    """Test PrefixImageScenario creation with explicit num_images."""
+    scenario = PrefixImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        prefix_tokens=1200,
+        suffix_tokens=300,
+        output_tokens=200,
+        num_images=3,
+    )
+    assert scenario.num_images == 3
+
+
+def test_prefix_image_single_image_default():
+    """4-param form (no num_images) defaults to 1 image — backward compat."""
+    scenario = PrefixImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        prefix_tokens=1200,
+        suffix_tokens=300,
+        output_tokens=200,
+    )
+    assert scenario.num_images == 1
+
+
+def test_prefix_image_multi_image_sampling():
+    """sample() returns the configured num_images, not hardcoded 1."""
+    scenario = PrefixImageScenario(
+        num_input_dimension_width=512,
+        num_input_dimension_height=512,
+        prefix_tokens=800,
+        suffix_tokens=200,
+        output_tokens=100,
+        num_images=5,
+    )
+    _, num_images, _, _, _ = scenario.sample()
+    assert num_images == 5
+
+
+def test_prefix_image_multi_image_to_string():
+    """5-param form roundtrips with num_images inside the parens."""
+    scenario = PrefixImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        prefix_tokens=1200,
+        suffix_tokens=300,
+        output_tokens=200,
+        num_images=3,
+    )
+    assert scenario.to_string() == "IP(1024,1024,1200,300,3)/200"
+
+
+def test_prefix_image_single_image_to_string_is_4param():
+    """Single-image form omits num_images from the string (legacy shape)."""
+    scenario = PrefixImageScenario(
+        num_input_dimension_width=1024,
+        num_input_dimension_height=1024,
+        prefix_tokens=1200,
+        suffix_tokens=300,
+        output_tokens=200,
+        num_images=1,
+    )
+    assert scenario.to_string() == "IP(1024,1024,1200,300)/200"
+
+
+def test_prefix_image_parse_multi_image():
+    """5-param form parses num_images from inside the parens."""
+    scenario = PrefixImageScenario.parse("(1024,1024,1200,300,3)/200")
+    assert scenario.num_input_dimension_width == 1024
+    assert scenario.prefix_tokens == 1200
+    assert scenario.suffix_tokens == 300
+    assert scenario.output_tokens == 200
+    assert scenario.num_images == 3
+
+
+def test_prefix_image_from_string_multi_image():
+    """Scenario.from_string routes the 5-param form correctly."""
+    scenario = Scenario.from_string("IP(1024,1024,1200,300,3)/200")
+    assert isinstance(scenario, PrefixImageScenario)
+    assert scenario.num_images == 3


### PR DESCRIPTION
## Summary

Follow-up to #28. Removes the `num_images` hardcoded-to-1 TODOs that @JimmyWhitaker flagged in his original review and re-raised after merge. The underlying sampler already supports `N > 1` via `_sample_images()` — the only gap was the scenario format/parsing, so this is a regex + `parse()` extension, not a feature.

## Syntax (Option A — trailing positional)

Chose the positional form because every other scenario in the DSL is pure positional (`N(480,240)/(300,150)`, `P(6262,167)/105`, `D(100,200)`, `RD(200)`). Introducing kwarg syntax in one scenario would fragment the DSL.

**ID() — 4-param form unchanged; add `N` at the end for multi-image:**
```
ID(w, h, input_tokens, output_tokens)           # 1 image (default, unchanged)
ID(w, h, input_tokens, output_tokens, N)        # N images
```

**IP() — 4-param form unchanged; add `N` inside the parens before `/output`:**
```
IP(w, h, prefix_tokens, suffix_tokens)/output          # 1 image (unchanged)
IP(w, h, prefix_tokens, suffix_tokens, N)/output       # N images
```

## Implementation notes

- `__init__(..., num_images: int = 1)` — every existing caller keeps working with zero changes.
- `validation_pattern` regex gains an optional `(?:,\d+)?` capture for the 5th param.
- `parse()` accepts 4 or 5 params. IP's `parse()` tries the 5-param regex first, falls back to 4.
- `to_string()` emits the 4-param shape when `num_images == 1`, so the canonical string for the common case matches the legacy output byte-for-byte (round-trip stability with existing benchmark history / result filenames).
- CLI help text in `option_groups.py` updated with both forms and worked examples.

## Test plan

- [x] 14 new tests for the 5-param forms: creation, sampling (`sample()` returns configured N), `to_string()`, `parse()`, `from_string()`, and single-image backward compat
- [x] Updated the existing "too many params" test case (5 params is now valid; bumped the invalid case to 6)
- [x] Local mypy (1.20.1 + transformers 5.5.4, matching CI): no issues
- [x] ruff format + check: clean
- [x] `pytest tests/scenarios/test_multimodal.py tests/sampling/test_image.py -q`: 52 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)