### PR TITLE
Add tokenizer-only fallback loading

### DIFF
--- a/genai_bench/cli/validation.py
+++ b/genai_bench/cli/validation.py
@@ -1,8 +1,10 @@
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import click
+from huggingface_hub import snapshot_download
 from huggingface_hub.utils import HfHubHTTPError
 from transformers import AutoTokenizer
 
@@ -81,6 +83,17 @@ DEFAULT_SCENARIOS_BY_TASK = {
     # add other tasks and default scenarios as needed
 }
 
+TOKENIZER_FILE_PATTERNS = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "chat_template.jinja",
+    "vocab.*",
+    "merges.txt",
+    "*.model",
+]
+
 
 # -------------------------
 # General Validation Functions
@@ -153,12 +166,38 @@ def validate_traffic_scenario_callback(ctx, param, value):
     return DEFAULT_SCENARIOS_BY_TASK[task]
 
 
+def _is_hf_auth_error(error):
+    if isinstance(error, HfHubHTTPError) and error.response is not None:
+        return error.response.status_code in {401, 403, 404}
+
+    if isinstance(error, OSError):
+        error_text = str(error)
+        return "gated repo" in error_text or (
+            "private repository" in error_text
+            and "make sure to pass a token" in error_text
+        )
+
+    return False
+
+
+def _load_tokenizer_from_tokenizer_files(model_tokenizer, hf_token):
+    tokenizer_dir = tempfile.mkdtemp(prefix="genai-bench-tokenizer-")
+    snapshot_download(
+        repo_id=model_tokenizer,
+        token=hf_token,
+        allow_patterns=TOKENIZER_FILE_PATTERNS,
+        local_dir=tokenizer_dir,
+    )
+    return AutoTokenizer.from_pretrained(tokenizer_dir)
+
+
 def validate_tokenizer(model_tokenizer):
     """Validate and load the tokenizer, either locally or from HuggingFace.
 
-    The function now tries an **anonymous** download first to support public
-    repositories without requiring an ``HF_TOKEN``. Authentication is only
-    enforced when the Hugging Face Hub returns *401* or *403* errors.
+    The function tries regular Transformers loading first. If that fails, it
+    downloads only standard tokenizer files and loads from that local directory.
+    Authentication is only enforced when the Hugging Face Hub reports an access
+    error and no ``HF_TOKEN`` is available.
     """
     if isinstance(model_tokenizer, str) and Path(model_tokenizer).exists():
         return AutoTokenizer.from_pretrained(model_tokenizer)
@@ -166,27 +205,29 @@ def validate_tokenizer(model_tokenizer):
 
     try:
         return AutoTokenizer.from_pretrained(model_tokenizer, token=hf_token)
-    except (HfHubHTTPError, OSError) as e:
-        is_auth_error = False
-
-        if isinstance(e, OSError):
-            if (
-                "gated repo" in str(e)
-                or "private repository" in str(e)
-                and "make sure to pass a token" in str(e)
-            ):
-                is_auth_error = True
-        elif isinstance(e, HfHubHTTPError) and e.response is not None:
-            is_auth_error = e.response.status_code in {401, 403, 404}
-
-        if is_auth_error and hf_token is None:
+    except Exception as e:
+        if _is_hf_auth_error(e) and hf_token is None:
             raise click.BadParameter(
                 "Hugging Face requires authentication for this tokenizer. "
                 "Please export HF_TOKEN with a valid access token and retry."
             ) from e
 
-        # Propagate all other errors unchanged
-        raise
+        try:
+            tokenizer = _load_tokenizer_from_tokenizer_files(model_tokenizer, hf_token)
+        except Exception as fallback_error:
+            if _is_hf_auth_error(fallback_error) and hf_token is None:
+                raise click.BadParameter(
+                    "Hugging Face requires authentication for this tokenizer. "
+                    "Please export HF_TOKEN with a valid access token and retry."
+                ) from fallback_error
+            # Propagate the original Transformers error so fallback details do not
+            # mask why normal tokenizer loading failed.
+            raise e from fallback_error
+
+        logger.info(
+            "Loaded tokenizer for %s from tokenizer files only", model_tokenizer
+        )
+        return tokenizer
 
 
 def validate_iteration_params(ctx, param, value) -> str:

--- a/tests/cli/test_validation.py
+++ b/tests/cli/test_validation.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import click
 import pytest
@@ -10,6 +10,7 @@ from genai_bench.cli.validation import (
     DEFAULT_BATCH_SIZES,
     DEFAULT_NUM_CONCURRENCIES,
     DEFAULT_SCENARIOS_BY_TASK,
+    TOKENIZER_FILE_PATTERNS,
     set_model_from_tokenizer,
     validate_additional_request_params,
     validate_api_backend,
@@ -175,20 +176,83 @@ def test_validate_tokenizer_access_errors(monkeypatch):
         "You are trying to access a gated repo.\n"
         "Make sure to have access to it at https://huggingface.co/meta-llama/Meta-Llama-3-8B."
     )
-    with patch("transformers.AutoTokenizer.from_pretrained", side_effect=gated_error):
+    with (
+        patch("transformers.AutoTokenizer.from_pretrained", side_effect=gated_error),
+        patch("genai_bench.cli.validation.snapshot_download") as mock_snapshot,
+    ):
         with pytest.raises(click.BadParameter) as exc_info:
             validate_tokenizer("meta-llama/Meta-Llama-3-8B")
         assert "Hugging Face requires authentication" in str(exc_info.value)
+        mock_snapshot.assert_not_called()
 
     # Test private repo error
     private_error = OSError(
         "private/model is not a local folder and is not a valid model identifier\n"
         "If this is a private repository, make sure to pass a token"
     )
-    with patch("transformers.AutoTokenizer.from_pretrained", side_effect=private_error):
+    with (
+        patch("transformers.AutoTokenizer.from_pretrained", side_effect=private_error),
+        patch("genai_bench.cli.validation.snapshot_download") as mock_snapshot,
+    ):
         with pytest.raises(click.BadParameter) as exc_info:
             validate_tokenizer("private/model")
         assert "Hugging Face requires authentication" in str(exc_info.value)
+        mock_snapshot.assert_not_called()
+
+
+def test_validate_tokenizer_falls_back_to_tokenizer_files(monkeypatch):
+    """Load only tokenizer files when regular tokenizer loading needs model config."""
+    hf_token = "mock_api_key"
+    model_name = "poolside/Laguna-XS.2-FP8"
+    mock_tokenizer = MagicMock()
+
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    monkeypatch.setenv("HF_TOKEN", hf_token)
+
+    with (
+        patch(
+            "genai_bench.cli.validation.AutoTokenizer.from_pretrained",
+            side_effect=[KeyError("original_max_position_embeddings"), mock_tokenizer],
+        ) as mock_from_pretrained,
+        patch("genai_bench.cli.validation.snapshot_download") as mock_snapshot,
+    ):
+        tokenizer = validate_tokenizer(model_name)
+
+    mock_snapshot.assert_called_once_with(
+        repo_id=model_name,
+        token=hf_token,
+        allow_patterns=TOKENIZER_FILE_PATTERNS,
+        local_dir=ANY,
+    )
+    tokenizer_dir = mock_snapshot.call_args.kwargs["local_dir"]
+    assert mock_from_pretrained.call_args_list == [
+        call(model_name, token=hf_token),
+        call(tokenizer_dir),
+    ]
+    assert tokenizer == mock_tokenizer
+
+
+def test_validate_tokenizer_fallback_reraises_original_error(monkeypatch):
+    """Preserve the original tokenizer error if tokenizer-file fallback fails."""
+    hf_token = "mock_api_key"
+    model_name = "broken/model"
+    original_error = KeyError("original")
+    fallback_error = ValueError("fallback")
+
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    monkeypatch.setenv("HF_TOKEN", hf_token)
+
+    with (
+        patch(
+            "genai_bench.cli.validation.AutoTokenizer.from_pretrained",
+            side_effect=[original_error, fallback_error],
+        ),
+        patch("genai_bench.cli.validation.snapshot_download"),
+    ):
+        with pytest.raises(KeyError) as exc_info:
+            validate_tokenizer(model_name)
+
+    assert exc_info.value is original_error
 
 
 def test_set_model_from_tokenizer():


### PR DESCRIPTION
## Summary
- add a generic tokenizer-only fallback when Transformers cannot load a tokenizer directly from a Hub repo
- preserve the existing auth error behavior for gated/private repos without HF_TOKEN
- add unit coverage for fallback success and original-error preservation

## Validation
- uv run pytest tests/cli/test_validation.py -q
- uv run --extra dev ruff check genai_bench/cli/validation.py tests/cli/test_validation.py
- uv run python - <<'PY'
from genai_bench.cli.validation import validate_tokenizer

tokenizer = validate_tokenizer('poolside/Laguna-XS.2-FP8')
print(type(tokenizer).__name__)
print(getattr(tokenizer, 'vocab_size', None))
PY