### PR TITLE
feat(cli): add RTX_PRO_6000 to --server-gpu-type choices

### DIFF
--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -371,6 +371,7 @@ def server_options(func):
                 "H100MIG",
                 "L4",
                 "A10G",
+                "RTX_PRO_6000",
             ],
             case_sensitive=True,
         ),


### PR DESCRIPTION
## Summary
- Add `RTX_PRO_6000` to the `--server-gpu-type` `click.Choice` allowlist in `genai_bench/cli/option_groups.py`.
- Today the CLI rejects this value with `Error: Invalid value for '--server-gpu-type'`, so callers benchmarking RTX PRO 6000 (Blackwell workstation) deployments have to drop the flag and lose that piece of server metadata in results.

## Test plan
- [x] `pytest tests/cli/test_cli_benchmark.py` — 15/15 pass
- [ ] Downstream `model-registry` action stops emitting the "not in allowlist" NOTE for RTX_PRO_6000 once this is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)