### PR TITLE
feat: add TokenSpeed to --server-engine choices

### DIFF
--- a/genai_bench/analysis/flexible_plot_report.py
+++ b/genai_bench/analysis/flexible_plot_report.py
@@ -473,7 +473,7 @@ class FlexiblePlotGenerator:
     ) -> None:
         """Plot multiple lines on the same subplot."""
         # Get colors from tab10 colormap
-        cmap = plt.cm.get_cmap("tab10")
+        cmap = plt.get_cmap("tab10")
         colors = [cmap(i) for i in range(10)]  # Get first 10 colors
         linestyles = ["-", "--", "-.", ":"]
 

--- a/genai_bench/cli/option_groups.py
+++ b/genai_bench/cli/option_groups.py
@@ -394,6 +394,7 @@ def server_options(func):
                 "SGLang",
                 "TGI",
                 "TRT-LLM",
+                "TokenSpeed",
                 "cohere-TensorRT",
                 "cohere-vLLM",
                 "LlamaCPP",


### PR DESCRIPTION
Adds `TokenSpeed` to the `--server-engine` choices in `cli/option_groups.py`.

It's a `click.Choice` label only (no behavioral dispatch on the value), so this just lets TokenSpeed-served deployments be benchmarked/labeled without the CLI rejecting `--server-engine TokenSpeed`.

**Also:** fixed an unrelated pre-existing mypy failure in `analysis/flexible_plot_report.py` — `plt.cm.get_cmap` was removed in matplotlib ≥3.9, swapped to `plt.get_cmap` (same `tab10` colormap, no behavior change). It was failing CI independently of this change; included here to get the build green.

